### PR TITLE
Fix local variable in method after class declaration

### DIFF
--- a/src/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorVarsDef.java
+++ b/src/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorVarsDef.java
@@ -202,6 +202,7 @@ public class VisitorVarsDef extends GetVisitedEntityAbstractVisitor {
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean visit(FieldDeclaration node) {
+		StructuralEntityKinds saved = structuralType;
 		structuralType = StructuralEntityKinds.ATTRIBUTE;
 
 		// creating the attribute(s)
@@ -216,7 +217,7 @@ public class VisitorVarsDef extends GetVisitedEntityAbstractVisitor {
 				vardecl.getInitializer().accept(this);
 			}
 		}
-
+		structuralType = saved;
 		return false;  // already visited all children
 	}
 

--- a/test_src/inner/InnerClass.java
+++ b/test_src/inner/InnerClass.java
@@ -20,4 +20,12 @@ public class InnerClass {
         };
     }
 
+    private myMethod() {
+        class AClass {
+            int i;
+            Object j;
+        }
+        AClass test = new AClass();
+    }
+
 }

--- a/tests/fr/inria/verveine/extractor/java/VerveineJTest_Inner.java
+++ b/tests/fr/inria/verveine/extractor/java/VerveineJTest_Inner.java
@@ -6,7 +6,9 @@ import org.junit.Test;
 import org.moosetechnology.model.famix.famixjavaentities.Class;
 import org.moosetechnology.model.famix.famixjavaentities.Interface;
 import org.moosetechnology.model.famix.famixjavaentities.Invocation;
+import org.moosetechnology.model.famix.famixjavaentities.Method;
 import org.moosetechnology.model.famix.famixjavaentities.NamedEntity;
+import org.moosetechnology.model.famix.famixtraits.TNamedEntity;
 
 import java.util.Collection;
 import java.util.Comparator;
@@ -39,11 +41,11 @@ public class VerveineJTest_Inner extends VerveineJTest_Basic {
     public void testNumberOfClass() {
         parse(new String[] {"test_src/inner"});
         Collection<Class> classes = entitiesOfType(Class.class);
-        assertEquals(11, classes.size());
+        assertEquals(12, classes.size());
         assertEquals(4, entitiesOfType(Interface.class).size());
         // Number of stubs
         assertEquals(8, classes.stream().filter(aClass -> aClass.getIsStub()).toArray().length);
-        assertEquals(3, classes.stream().filter(aClass -> !aClass.getIsStub()).toArray().length); // InnerClass, _Anonymous(Patate), _Anonymous(Canard)
+        assertEquals(4, classes.stream().filter(aClass -> !aClass.getIsStub()).toArray().length); // InnerClass, _Anonymous(Patate), _Anonymous(Canard)
         assertEquals(2, classes.stream().filter(aClass -> !aClass.getIsStub() && aClass.getName().contains("Anonymous")).toArray().length); // InnerClass, _Anonymous(Patate), _Anonymous(Canard)
     }
 
@@ -61,9 +63,20 @@ public class VerveineJTest_Inner extends VerveineJTest_Basic {
         List<Invocation> invocations = entitiesOfType(Invocation.class).stream()
                 .sorted(Comparator.comparing(anInvocation2 -> ((Invocation) anInvocation2).getSignature()))
                 .collect(Collectors.toList());
-        assertEquals(invocations.size(), 3);
-        assert(invocations.get(0).getSignature().startsWith("_Anonymous(Canard)(new Patate()"));
-        assert(invocations.get(1).getSignature().startsWith("_Anonymous(Patate)()"));
+        assertEquals(invocations.size(), 4);
+        assert(invocations.get(1).getSignature().startsWith("_Anonymous(Canard)(new Patate()"));
+        assert(invocations.get(2).getSignature().startsWith("_Anonymous(Patate)()"));
+    }
+
+    @Test
+    public void testMyMethodHasLocalVariableTest() {
+        parse(new String[] {"test_src/inner"});
+        List<Method> methods = entitiesOfType(Method.class).stream()
+            .filter(m -> m.getName().equals("myMethod"))
+            .collect(Collectors.toList());
+        assertEquals(methods.size(), 1);
+        assertEquals(methods.get(0).getLocalVariables().size(),1);
+        assertEquals(((TNamedEntity)firstElt(methods.get(0).getLocalVariables())).getName(),"test");
     }
 
 }


### PR DESCRIPTION
This PR aims to fix the parsing of such a Java piece of code

```java
    private myMethod() {
        class AClass {
            int i;
            Object j;
        }
        AClass test = new AClass();
    }
```

In which the variable `test` was tried to be considered as an Attribute instead of a LocalVariable, and thus crashing the parser