### PR TITLE
fix case with comment

### DIFF
--- a/src/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorComments.java
+++ b/src/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorComments.java
@@ -16,6 +16,7 @@ import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
 import org.eclipse.jdt.core.dom.Comment;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.EnumDeclaration;
+import org.eclipse.jdt.core.dom.Initializer;
 import org.eclipse.jdt.core.dom.Javadoc;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
@@ -28,8 +29,11 @@ import org.moosetechnology.model.famix.famixtraits.TWithComments;
 
 import fr.inria.verveine.extractor.java.EntityDictionary;
 import fr.inria.verveine.extractor.java.VerveineJOptions;
+import fr.inria.verveine.extractor.java.utils.StructuralEntityKinds;
 import fr.inria.verveine.extractor.java.visitors.GetVisitedEntityAbstractVisitor;
 
+
+import org.moosetechnology.model.famix.famixjavaentities.LocalVariable;
 /**
  * A class to collect all comments.
  * Some important details on comments in JDT:
@@ -202,6 +206,19 @@ public class VisitorComments extends GetVisitedEntityAbstractVisitor {
 		assignCommentsBefore(node, node.getJavadoc(), fmx);
 
 		return super.visit(node);
+	}
+
+	@Override
+	public boolean visit(Initializer node) {
+		visitInitializer(node);
+		classMemberDeclarations = false;
+		return super.visit(node);
+	}
+
+	@Override
+	public void endVisit(Initializer node) {
+		classMemberDeclarations = true;
+		endVisitInitializer(node);
 	}
 
 	@Override

--- a/test_src/comments/ClassWithComments.java
+++ b/test_src/comments/ClassWithComments.java
@@ -16,6 +16,15 @@ public class ClassWithComments {
 	 */
 	private int y;
 
+    static {
+        try {
+            // Url comment
+            final Object url = new Object();
+        } catch (final Exception ex) {
+            // Fichier non trouvé ou incorrect. Il est facultatif donc pas de message.
+        }
+    }
+
 	// simple constructor
 	ClassWithComments(){
     }

--- a/tests/fr/inria/verveine/extractor/java/VerveineJTest_CommentsMethod.java
+++ b/tests/fr/inria/verveine/extractor/java/VerveineJTest_CommentsMethod.java
@@ -1,6 +1,5 @@
 package fr.inria.verveine.extractor.java;
 
-
 import org.junit.Before;
 import org.junit.Test;
 import org.moosetechnology.model.famix.famixjavaentities.IndexedFileAnchor;
@@ -9,9 +8,10 @@ import org.moosetechnology.model.famix.famixjavaentities.Method;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
-
 
 public class VerveineJTest_CommentsMethod extends VerveineJTest_Basic {
 
@@ -28,105 +28,124 @@ public class VerveineJTest_CommentsMethod extends VerveineJTest_Basic {
         repo = parser.getFamixRepo();
     }
 
-	private void parse(String[] sources) {
+    private void parse(String[] sources) {
         parser.configure(sources);
         parser.parse();
     }
 
     /**
-     * Helper method to get the starting position of a method and convert it to <code>Integer</code> (to be able to use <code>compareTo()</code> on it)
+     * Helper method to get the starting position of a method and convert it to
+     * <code>Integer</code> (to be able to use <code>compareTo()</code> on it)
      */
     private Integer startPos(Method mth) {
-		return (Integer) ((IndexedFileAnchor)mth.getSourceAnchor()).getStartPos().intValue();
-	}
+        return (Integer) ((IndexedFileAnchor) mth.getSourceAnchor()).getStartPos().intValue();
+    }
 
     /**
-     * Another helper method for the end position of a method, but this one does not need converting to <code>Integer</code>
+     * Another helper method for the end position of a method, but this one does not
+     * need converting to <code>Integer</code>
      */
     private int endPos(Method method) {
-		return ((IndexedFileAnchor) method.getSourceAnchor()).getEndPos().intValue();
-	}
+        return ((IndexedFileAnchor) method.getSourceAnchor()).getEndPos().intValue();
+    }
 
     @Test
     public void testStartPosSourceAnchorMethod() {
-        parse(new String[] {"test_src/comments"});
+        parse(new String[] { "test_src/comments" });
 
-        List<Method> methods  = new ArrayList<>();
-        // convert to <code>List</code> to be able to sort them by ascending starting position
+        List<Method> methods = new ArrayList<>();
+        // convert to <code>List</code> to be able to sort them by ascending starting
+        // position
         methods.addAll(entitiesOfType(Method.class));
-        assertEquals(10, methods.size());
+        assertEquals(12, methods.size());
 
-        methods.sort( (o1, o2) -> startPos(o1).compareTo(startPos(o2)) );
-        if(isWindows()){
-        	// on Windows need to add one character for each end-of-line
-            assertEquals( (Integer)(231+20), startPos(methods.get(0))); // ClassWithComments()
-            assertEquals( (Integer)(292+24), startPos(methods.get(1))); // ClassWithComments(int i)
-            assertEquals( (Integer)(374+30), startPos(methods.get(2))); // ClassWithComments(int i, int j)
-            assertEquals( (Integer)(518+37), startPos(methods.get(3))); // method1()
-            assertEquals( (Integer)(591+41), startPos(methods.get(4))); // method2(int i)
-            assertEquals( (Integer)(773+50), startPos(methods.get(5))); // method3(int i, int j)
-            assertEquals( (Integer)(811+53), startPos(methods.get(6))); // method4()
-            assertEquals( (Integer)(893+57), startPos(methods.get(7))); // method5(double a)
-            assertEquals( (Integer)(1000+63), startPos(methods.get(8))); // method6(double a, double b)
-            assertEquals( (Integer)(1117+69), startPos(methods.get(9))); // methodWithoutBody(double a, double b, double c)
+        List<Method> methodsWithAnchor = methods.stream().filter(m -> m.getSourceAnchor() != null)
+                .collect(Collectors.toList());
+        methodsWithAnchor.sort((o1, o2) -> startPos(o1).compareTo(startPos(o2)));
+        if (isWindows()) {
+            // on Windows need to add one character for each end-of-line
+            assertEquals((Integer) (211 + 18), startPos(methodsWithAnchor.get(0))); // <Initializer>
+            assertEquals((Integer) (473 + 28), startPos(methodsWithAnchor.get(1))); // ClassWithComments()
+            assertEquals((Integer) (534 + 32), startPos(methodsWithAnchor.get(2))); // ClassWithComments(int i)
+            assertEquals((Integer) (616 + 38), startPos(methodsWithAnchor.get(3))); // ClassWithComments(int i, int j)
+            assertEquals((Integer) (760 + 45), startPos(methodsWithAnchor.get(4))); // method1()
+            assertEquals((Integer) (833 + 49), startPos(methodsWithAnchor.get(5))); // method2(int i)
+            assertEquals((Integer) (1015 + 58), startPos(methodsWithAnchor.get(6))); // method3(int i, int j)
+            assertEquals((Integer) (1053 + 61), startPos(methodsWithAnchor.get(7))); // method4()
+            assertEquals((Integer) (1135 + 65), startPos(methodsWithAnchor.get(8))); // method5(double a)
+            assertEquals((Integer) (1242 + 71), startPos(methodsWithAnchor.get(9))); // method6(double a, double b)
+            assertEquals((Integer) (1359 + 77), startPos(methodsWithAnchor.get(10))); // methodWithoutBody(double a,
+                                                                                      // double b, double c)
         } else {
-            assertEquals( (Integer)231, startPos(methods.get(0))); // ClassWithComments()
-            assertEquals( (Integer)292, startPos(methods.get(1))); // ClassWithComments(int i)
-            assertEquals( (Integer)374, startPos(methods.get(2))); // ClassWithComments(int i, int j)
-            assertEquals( (Integer)518, startPos(methods.get(3))); // method1()
-            assertEquals( (Integer)591, startPos(methods.get(4))); // method2(int i)
-            assertEquals( (Integer)773, startPos(methods.get(5))); // method3(int i, int j)
-            assertEquals( (Integer)811, startPos(methods.get(6))); // method4()
-            assertEquals( (Integer)893, startPos(methods.get(7))); // method5(double a)
-            assertEquals( (Integer)1000, startPos(methods.get(8))); // method6(double a, double b)
-            assertEquals( (Integer)1117, startPos(methods.get(9))); // methodWithoutBody(double a, double b, double c)
+            assertEquals((Integer) (211), startPos(methodsWithAnchor.get(0))); // <Initializer>
+            assertEquals((Integer) (473), startPos(methodsWithAnchor.get(1))); // ClassWithComments()
+            assertEquals((Integer) (534), startPos(methodsWithAnchor.get(2))); // ClassWithComments(int i)
+            assertEquals((Integer) (616), startPos(methodsWithAnchor.get(3))); // ClassWithComments(int i, int j)
+            assertEquals((Integer) (760), startPos(methodsWithAnchor.get(4))); // method1()
+            assertEquals((Integer) (833), startPos(methodsWithAnchor.get(5))); // method2(int i)
+            assertEquals((Integer) (1015), startPos(methodsWithAnchor.get(6))); // method3(int i, int j)
+            assertEquals((Integer) (1053), startPos(methodsWithAnchor.get(7))); // method4()
+            assertEquals((Integer) (1135), startPos(methodsWithAnchor.get(8))); // method5(double a)
+            assertEquals((Integer) (1242), startPos(methodsWithAnchor.get(9))); // method6(double a, double b)
+            assertEquals((Integer) (1359), startPos(methodsWithAnchor.get(10))); // methodWithoutBody(double a, double
+                                                                                 // b, double c)
         }
     }
 
-	@Test
+    @Test
     public void testEndPosSourceAnchorMethod() {
-        parse(new String[] {"test_src/comments"});
-        List<Method> methods  = new ArrayList<>();
+        parse(new String[] { "test_src/comments" });
+        List<Method> methods = new ArrayList<>();
+        // convert to <code>List</code> to be able to sort them by ascending starting
+        // position
         methods.addAll(entitiesOfType(Method.class));
-        methods.sort(Comparator.comparing(o -> ((IndexedFileAnchor) o.getSourceAnchor()).getEndPos().intValue()));
-        assertEquals(10, methods.size());
-        if(isWindows()){
-        	// on Windows need to add one character for each end-of-line
-            assertEquals(256+21, endPos(methods.get(0))); // ClassWithComments()
-            assertEquals(322+25, endPos(methods.get(1))); // ClassWithComments(int i)
-            assertEquals(481+34, endPos(methods.get(2))); // ClassWithComments(int i, int j)
-            assertEquals(537+38, endPos(methods.get(3))); // method1()
-            assertEquals(703+45, endPos(methods.get(4))); // method2(int i)
-            assertEquals(804+51, endPos(methods.get(5))); // method3(int i, int j)
-            assertEquals(837+54, endPos(methods.get(6))); // method4()
-            assertEquals(927+58, endPos(methods.get(7))); // method5(double a)
-            assertEquals(1044+64, endPos(methods.get(8))); // method6(double a, double b)
-            assertEquals(1175+69, endPos(methods.get(9))); // methodWithoutBody(double a, double b, double c)
+        assertEquals(12, methods.size());
+
+        List<Method> methodsWithAnchor = methods.stream().filter(m -> m.getSourceAnchor() != null)
+                .collect(Collectors.toList());
+        assertEquals(11, methodsWithAnchor.size());
+        methodsWithAnchor.sort((o1, o2) -> startPos(o1).compareTo(startPos(o2)));
+        if (isWindows()) {
+            // on Windows need to add one character for each end-of-line
+            assertEquals(446 + 25, endPos(methodsWithAnchor.get(0))); // <Initializer>
+            assertEquals(498 + 29, endPos(methodsWithAnchor.get(1))); // ClassWithComments()
+            assertEquals(564 + 33, endPos(methodsWithAnchor.get(2))); // ClassWithComments(int i)
+            assertEquals(723 + 42, endPos(methodsWithAnchor.get(3))); // ClassWithComments(int i, int j)
+            assertEquals(779 + 46, endPos(methodsWithAnchor.get(4))); // method1()
+            assertEquals(945 + 53, endPos(methodsWithAnchor.get(5))); // method2(int i)
+            assertEquals(1046 + 59, endPos(methodsWithAnchor.get(6))); // method3(int i, int j)
+            assertEquals(1079 + 62, endPos(methodsWithAnchor.get(7))); // method4()
+            assertEquals(1169 + 66, endPos(methodsWithAnchor.get(8))); // method5(double a)
+            assertEquals(1286 + 72, endPos(methodsWithAnchor.get(9))); // method6(double a, double b)
+            assertEquals(1417 + 77, endPos(methodsWithAnchor.get(10))); // methodWithoutBody(double a, double b, double c)
         } else {
-            assertEquals(256, endPos(methods.get(0))); // ClassWithComments()
-            assertEquals(322, endPos(methods.get(1))); // ClassWithComments(int i)
-            assertEquals(481, endPos(methods.get(2))); // ClassWithComments(int i, int j)
-            assertEquals(537, endPos(methods.get(3))); // method1()
-            assertEquals(703, endPos(methods.get(4))); // method2(int i)
-            assertEquals(804, endPos(methods.get(5))); // method3(int i, int j)
-            assertEquals(837, endPos(methods.get(6))); // method4()
-            assertEquals(927, endPos(methods.get(7))); // method5(double a)
-            assertEquals(1044, endPos(methods.get(8))); // method6(double a, double b)
-            assertEquals(1175, endPos(methods.get(9))); // methodWithoutBody(double a, double b, double c)
+            assertEquals(446, endPos(methodsWithAnchor.get(0))); // <Initializer>
+            assertEquals(498, endPos(methodsWithAnchor.get(1))); // ClassWithComments()
+            assertEquals(564, endPos(methodsWithAnchor.get(2))); // ClassWithComments(int i)
+            assertEquals(723, endPos(methodsWithAnchor.get(3))); // ClassWithComments(int i, int j)
+            assertEquals(779, endPos(methodsWithAnchor.get(4))); // method1()
+            assertEquals(945, endPos(methodsWithAnchor.get(5))); // method2(int i)
+            assertEquals(1046, endPos(methodsWithAnchor.get(6))); // method3(int i, int j)
+            assertEquals(1079, endPos(methodsWithAnchor.get(7))); // method4()
+            assertEquals(1169, endPos(methodsWithAnchor.get(8))); // method5(double a)
+            assertEquals(1286, endPos(methodsWithAnchor.get(9))); // method6(double a, double b)
+            assertEquals(1417, endPos(methodsWithAnchor.get(10))); // methodWithoutBody(double a, double b, double c)
         }
     }
 
-	@Test
+    @Test
     public void testSourceAnchorHasFile() {
-        parse(new String[] {"test_src/comments"});
-        List<Method> methods  = new ArrayList<>();
-        methods.addAll(entitiesOfType(Method.class));
-        assertEquals(10, methods.size());
-        for(Method method: methods){
-            assertEquals("test_src/comments/ClassWithComments.java", ((IndexedFileAnchor)method.getSourceAnchor()).getFileName());
+        parse(new String[] { "test_src/comments" });
+        List<Method> methods = new ArrayList<>();
+         methods.addAll(entitiesOfType(Method.class));
+        assertEquals(12, methods.size());
+
+        List<Method> methodsWithAnchor = methods.stream().filter(m -> m.getSourceAnchor() != null)
+                .collect(Collectors.toList());
+        for (Method method : methodsWithAnchor) {
+            assertEquals("test_src/comments/ClassWithComments.java",
+                    ((IndexedFileAnchor) method.getSourceAnchor()).getFileName());
         }
     }
-
-
 
 }

--- a/tests/fr/inria/verveine/extractor/java/VerveineJTest_Configuration.java
+++ b/tests/fr/inria/verveine/extractor/java/VerveineJTest_Configuration.java
@@ -161,11 +161,11 @@ public class VerveineJTest_Configuration extends VerveineJTest_Basic {
 	public void testCommentsText() {
 		parse(new String[]{"-commenttext", "test_src/comments"});
 
-		assertEquals(14, entitiesOfType(Comment.class).size());
+		assertEquals(16, entitiesOfType(Comment.class).size());
 		for (Comment cmt : entitiesOfType(Comment.class)) {
 			assertNull(cmt.getSourceAnchor());
 			assertNotNull( cmt.getContent());
-			assertTrue( cmt.getContent().length() > 20); // none of the comments have less than 20 characters
+			assertTrue( cmt.getContent().length() > 10); // none of the comments have less than 20 characters
 			assertEquals('/', cmt.getContent().charAt(0));
 		}
 
@@ -180,7 +180,7 @@ public class VerveineJTest_Configuration extends VerveineJTest_Basic {
 		}
 		assertEquals(2, numberTested);  // check that all attributes were actually found and tested
 
-		assertEquals(10, entitiesOfType(Method.class).size());
+		assertEquals(12, entitiesOfType(Method.class).size());
 		for (Method meth : entitiesOfType(Method.class)) {
 			if (meth.getSignature().equals("ClassWithComments(int i, int j)")) {
 				numberTested++;

--- a/tests/fr/inria/verveine/extractor/java/VerveineJTest_Configuration.java
+++ b/tests/fr/inria/verveine/extractor/java/VerveineJTest_Configuration.java
@@ -210,12 +210,12 @@ public class VerveineJTest_Configuration extends VerveineJTest_Basic {
 	public void testCommentsAnchor() {
 		parse(new String[]{"test_src/comments"});
 
-		assertEquals(14, entitiesOfType(Comment.class).size());
+		assertEquals(16, entitiesOfType(Comment.class).size());
 		for (Comment cmt : entitiesOfType(Comment.class)) {
 			assertNotNull(cmt.getSourceAnchor());
 			assertNull( cmt.getContent());
 			int len = (int)((IndexedFileAnchor)cmt.getSourceAnchor()).getEndPos() - (int)((IndexedFileAnchor)cmt.getSourceAnchor()).getStartPos();
-			assertTrue( len >= 20); // none of the comments have less than 20 characters
+			assertTrue( len >= 10); // none of the comments have less than 20 characters
 		}
 	}
 


### PR DESCRIPTION
Comments in static initializer raises error

```java

    static {
        try {
            // Url comment
            final Object url = new Object();
        } catch (final Exception ex) {
            // Fichier non trouvé ou incorrect. Il est facultatif donc pas de message.
        }
    }
```

This PR deals with the above error and allow one to parse a full file