### PR TITLE
72 Change default format

### DIFF
--- a/app/src/main/java/fr/inria/verveine/extractor/java/VerveineJOptions.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/VerveineJOptions.java
@@ -156,7 +156,8 @@ public class VerveineJOptions {
 				throw e;
 			}
 		}
-		if ((outputFormat == JSON_OUTPUT_FORMAT) && (incrementalParsing) ) {
+
+		if ((outputFormat.equals(JSON_OUTPUT_FORMAT)) && (incrementalParsing) ) {
 			IllegalArgumentException illegalArgumentException = new IllegalArgumentException("-i option requires mse format.");
 			System.err.println(illegalArgumentException.getMessage());
 			usage();

--- a/app/src/main/java/fr/inria/verveine/extractor/java/VerveineJOptions.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/VerveineJOptions.java
@@ -157,7 +157,7 @@ public class VerveineJOptions {
 			}
 		}
 
-		if ((outputFormat.equals(JSON_OUTPUT_FORMAT)) && (incrementalParsing) ) {
+		if (JSON_OUTPUT_FORMAT.equalsIgnoreCase(outputFormat) && (incrementalParsing) ) {
 			IllegalArgumentException illegalArgumentException = new IllegalArgumentException("-i option requires mse format.");
 			System.err.println(illegalArgumentException.getMessage());
 			usage();

--- a/app/src/main/java/fr/inria/verveine/extractor/java/VerveineJOptions.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/VerveineJOptions.java
@@ -136,7 +136,7 @@ public class VerveineJOptions {
 		this.commentText = false;
 		this.incrementalParsing = false;
 		this.outputFileName = null;
-		this.outputFormat = MSE_OUTPUT_FORMAT;
+		this.outputFormat = JSON_OUTPUT_FORMAT;
 		this.debugging = false;
 	}
 

--- a/app/src/main/java/fr/inria/verveine/extractor/java/VerveineJOptions.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/VerveineJOptions.java
@@ -136,7 +136,7 @@ public class VerveineJOptions {
 		this.commentText = false;
 		this.incrementalParsing = false;
 		this.outputFileName = null;
-		this.outputFormat = JSON_OUTPUT_FORMAT;
+		this.outputFormat = null; //We need to know if the user sets this option manually. After parsing options, this will be set to the default format if it is still null.
 		this.debugging = false;
 	}
 
@@ -154,6 +154,20 @@ public class VerveineJOptions {
 				System.err.println(e.getMessage());
 				usage();
 				throw e;
+			}
+		}
+		if ((outputFormat == JSON_OUTPUT_FORMAT) && (incrementalParsing) ) {
+			IllegalArgumentException illegalArgumentException = new IllegalArgumentException("-i option requires mse format.");
+			System.err.println(illegalArgumentException.getMessage());
+			usage();
+			throw illegalArgumentException;
+		}
+
+		if (outputFormat == null) {
+			if (incrementalParsing) {
+				outputFormat = MSE_OUTPUT_FORMAT;
+			} else {
+				outputFormat= JSON_OUTPUT_FORMAT;
 			}
 		}
 
@@ -227,13 +241,14 @@ public class VerveineJOptions {
 			}
 		} else if (arg.equals("-i")) {
 			incrementalParsing = true;
+
 		}
 		else if (arg.equals("-debugging")) {
 				debugging = true;
 		} else {
 			throw new IllegalArgumentException("** Unrecognized option: " + arg);
 		}
-	
+
 		return argumentsTreated;
 	}
 

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_Basic.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_Basic.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.*;
 
 public abstract class VerveineJTest_Basic {
 
-	protected static final String DEFAULT_OUTPUT_FILE = "output.mse";
+	protected static final String DEFAULT_OUTPUT_FILE = "output.json";
 
 	protected Repository repo;
 	protected VerveineJParser parser;

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_Configuration.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_Configuration.java
@@ -2,10 +2,13 @@ package fr.inria.verveine.extractor.java;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.Assert;
 import org.moosetechnology.model.famix.famixjavaentities.*;
 import org.moosetechnology.model.famix.famixjavaentities.Class;
 import org.moosetechnology.model.famix.famixtraits.TAccess;
 import org.moosetechnology.model.famix.famixtraits.TNamedEntity;
+
+//import junit.framework.Assert;
 
 import java.io.File;
 import java.io.FileReader;
@@ -37,7 +40,7 @@ public class VerveineJTest_Configuration extends VerveineJTest_Basic {
 
 
 	private void parse(String[] sources) {
-		parser.configure( sources);
+		parser.configure(sources);
 		parser.parse();
 	}
 
@@ -351,5 +354,16 @@ public class VerveineJTest_Configuration extends VerveineJTest_Basic {
         }
         assertEquals(3, count);
     }
+
+
+	@Test
+	public void testFormatAndIncrementalIncompatibility() {
+		String[] args = new String[] {
+			"-format", "json",
+			"-i",
+			"src/test/resources/LANModel/moose/lan/server/PrintServer.java",
+		};
+		assertThrows(IllegalArgumentException.class, () -> parser.configure(args));
+	}
 
 }

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_Configuration.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_Configuration.java
@@ -17,8 +17,8 @@ import static org.junit.Assert.*;
 
 public class VerveineJTest_Configuration extends VerveineJTest_Basic {
 
-	private static final String OTHER_MSE_FILE = "other_output.mse";
-	private static final String JSON_OUTPUT_FILE = "output.json";
+	private static final String OTHER_JSON_FILE = "other_output.json";
+	private static final String MSE_OUTPUT_FILE = "output.mse";
 
 
 	public VerveineJTest_Configuration() {
@@ -44,7 +44,7 @@ public class VerveineJTest_Configuration extends VerveineJTest_Basic {
 	@Test
 	public void testChangeOutputFilePath() {
 		File defaultMSE = new File(DEFAULT_OUTPUT_FILE);
-		File alternateMSE = new File(OTHER_MSE_FILE);
+		File alternateMSE = new File(OTHER_JSON_FILE);
 
 		defaultMSE.delete();
 		alternateMSE.delete();  // delete it now
@@ -53,7 +53,7 @@ public class VerveineJTest_Configuration extends VerveineJTest_Basic {
 		assertFalse(defaultMSE.exists());
 		assertFalse(alternateMSE.exists());
 
-		parse(new String[]{"-o", OTHER_MSE_FILE, "src/test/resources/LANModel/moose/lan/Node.java"});
+		parse(new String[]{"-o", OTHER_JSON_FILE, "src/test/resources/LANModel/moose/lan/Node.java"});
 		parser.exportModel();
 
 		assertFalse(defaultMSE.exists());
@@ -65,19 +65,18 @@ public class VerveineJTest_Configuration extends VerveineJTest_Basic {
 	 * This is very crude, JSON files start with "[{" while MSE files start with "("
 	 */
 	@Test
-	public void testValidJSonFormat() {
-		File defaultJSON = new File(JSON_OUTPUT_FILE);
-		defaultJSON.delete();
-		defaultJSON.deleteOnExit();
+	public void testValidMSEFormat() {
+		File defaultMSE = new File(MSE_OUTPUT_FILE);
+		defaultMSE.delete();
+		defaultMSE.deleteOnExit();
 
-		parse(new String[]{"-format", "json", "src/test/resources/LANModel/moose/lan/Node.java"});
+		parse(new String[]{"-format", "mse", "src/test/resources/LANModel/moose/lan/Node.java"});
 		parser.exportModel();
 
 		FileReader reader;
 		try {
-			reader = new FileReader(defaultJSON);
-			assertEquals('[', reader.read());
-			assertEquals('{', reader.read());
+			reader = new FileReader(defaultMSE);
+			assertEquals('(', reader.read());
 		} catch (IOException e) {
 			fail("Input/Output error during the test");
 		}
@@ -85,21 +84,21 @@ public class VerveineJTest_Configuration extends VerveineJTest_Basic {
 
 	@Test
 	public void testChangeOutputFormat() {
-		File defaultMSE = new File(DEFAULT_OUTPUT_FILE);
-		File defaultJSON = new File(JSON_OUTPUT_FILE);
+		File defaultJSON = new File(DEFAULT_OUTPUT_FILE);
+		File defaultMSE = new File(MSE_OUTPUT_FILE);
 
-		defaultMSE.delete();
-		defaultJSON.delete();  // delete it now
-		defaultJSON.deleteOnExit();  // and delete it also after we are done
+		defaultJSON.delete();
+		defaultMSE.delete();  // delete it now
+		defaultMSE.deleteOnExit();  // and delete it also after we are done
 
-		assertFalse(defaultMSE.exists());
 		assertFalse(defaultJSON.exists());
+		assertFalse(defaultMSE.exists());
 
-		parse(new String[]{"-format", "json", "src/test/resources/LANModel/moose/lan/Node.java"});
+		parse(new String[]{"-format", "mse", "src/test/resources/LANModel/moose/lan/Node.java"});
 		parser.exportModel();
 
-		assertTrue(defaultJSON.exists());
-		assertFalse(defaultMSE.exists());
+		assertTrue(defaultMSE.exists());
+		assertFalse(defaultJSON.exists());
 	}
 
 	@Test

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_LanModel.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_LanModel.java
@@ -112,7 +112,7 @@ public class VerveineJTest_LanModel extends VerveineJTest_Basic {
 		parser.configure(args);
 		parser.parse();
 
-		new File(DEFAULT_OUTPUT_FILE).delete(); // delete old MSE file
+		new File(DEFAULT_OUTPUT_FILE).delete(); // delete old JSON file
 		System.gc(); // In Windows free the link to the file. Must be used for incremental parsing
 						// tests
 		parser.exportModel(); // to create a new one

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_LanModel.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_LanModel.java
@@ -59,6 +59,8 @@ public class VerveineJTest_LanModel extends VerveineJTest_Basic {
 
 	private static final String A_CLASS_NAME = "--aClassName--";
 
+	private static final String DEFAULT_MSE_FILE = "output.mse";
+
 	public VerveineJTest_LanModel() throws IllegalAccessException {
 		super(true);
 	}
@@ -68,7 +70,7 @@ public class VerveineJTest_LanModel extends VerveineJTest_Basic {
 	 */
 	@Before
 	public void setUp() throws Exception {
-		new File(DEFAULT_OUTPUT_FILE).delete();
+		new File(DEFAULT_MSE_FILE).delete();
 
 		String[] files = new String[] {
 


### PR DESCRIPTION
Fix #72 - Make JSON the default format.

⚠️ When using incremental parsing, an mse file is required, so the default is mse in this case.