### PR TITLE
Allow to modelize classes named Object

### DIFF
--- a/app/src/main/java/fr/inria/verveine/extractor/java/EntityDictionary.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/EntityDictionary.java
@@ -1102,7 +1102,9 @@ public class EntityDictionary {
 			}
 		}
 
-		if (name.equals(OBJECT_NAME)) { // TODO && owner == java.lang
+        // We should ensure the creation of Object only if the owner is the Object from java.lang. The problem is that sometimes the owner is null. or now we consider that if the owner is null, we have the Object of java.lang.
+        boolean ownerIsJavaLang = (owner == null) || "java.lang".equals(owner.getName());
+		if (name.equals(OBJECT_NAME) && ownerIsJavaLang) {
 			return ensureFamixClassObject(bnd);
 		}
 
@@ -2916,13 +2918,18 @@ public class EntityDictionary {
 	 * @return a Famix class for "Object"
 	 */
 	public Class ensureFamixClassObject(ITypeBinding bnd) {
-		Class fmx = ensureFamixUniqEntity(Class.class, bnd, OBJECT_NAME);
+        // In the past we used #ensureFamixUniqEntity but that does not check that the parent package is right and we got some Object from other packages than java.lang...
+        Collection<Class> objects = getEntityByName(Class.class, "Object");
 
-		if (fmx != null) {
-			fmx.setTypeContainer(ensureFamixPackageJavaLang(null));
-		}
-		// Note: "Object" has no superclass
+        for (Class entity : objects) {
+                //We need to cast because the type container is a FamixTWithType but all implementors of this should be named in Java...
+                if ("java.lang".equals(((TNamedEntity) entity.getTypeContainer()).getName())) {
+                    return entity;
+                }
+        }
 
+        Class fmx = createFamixEntity(Class.class, "Object");
+        fmx.setTypeContainer(ensureFamixPackageJavaLang(null));
 		return fmx;
 	}
 

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_AdHoc.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_AdHoc.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.moosetechnology.model.famix.famixjavaentities.*;
 import org.moosetechnology.model.famix.famixjavaentities.Enum;
 import org.moosetechnology.model.famix.famixjavaentities.Package;
+import org.moosetechnology.model.famix.famixjavaentities.Class;
 import org.moosetechnology.model.famix.famixtraits.*;
 
 import fr.inria.verveine.extractor.java.utils.Util;
@@ -901,6 +902,26 @@ public class VerveineJTest_AdHoc extends VerveineJTest_Basic {
         assertTrue(method.getIsDefault());
         assertEquals(EntityDictionary.DEFAULT_IMPLEMENTATION_KIND_MARKER, method.getKind());
 
+    }
+
+    @Test
+    /*
+    * Issue: https://github.com/moosetechnology/VerveineJ/issues/175
+    * Regression test ensuring that a class named Object does not always have "java.lang" as owner
+     */
+    public void testOwnerOfObjectIsNotAlwaysJavaLang() {
+        parse(new String[]{"src/test/resources/ad_hoc/Object.java"});
+
+        Collection<Class> classes = entitiesNamed(Class.class, "Object");
+        assertTrue("We should have at least java.lang.Object and adhoc.Object", classes.size() > 1);
+
+        //Maybe we can do the next line simpler but I'm bad in Java :'(
+        List<String> names = new ArrayList<>(classes.size());
+        for (Class c : classes) {
+            names.add(((TNamedEntity) c.getTypeContainer()).getName());
+        }
+
+        assertTrue(names.containsAll(Arrays.asList("lang", "ad_hoc")));
     }
 }
 

--- a/app/src/test/resources/ad_hoc/Object.java
+++ b/app/src/test/resources/ad_hoc/Object.java
@@ -1,0 +1,7 @@
+package ad_hoc;
+
+public class Object {
+
+
+
+}


### PR DESCRIPTION
Up until now, if we had a class named Object then it was merging it with java.lang.Object.

Fixes #175