### PR TITLE
Adding an option to parse JDKs (with a JDK version < 9)

### DIFF
--- a/app/resources/java/lang/Object.java
+++ b/app/resources/java/lang/Object.java
@@ -1,0 +1,5 @@
+package java.lang;
+
+public class Object {
+
+}

--- a/app/resources/java/lang/String.java
+++ b/app/resources/java/lang/String.java
@@ -1,0 +1,6 @@
+package java.lang;
+
+public class String {
+	public String(char value[]) {
+	}
+}

--- a/app/resources/javalanguser/Toto.java
+++ b/app/resources/javalanguser/Toto.java
@@ -1,0 +1,10 @@
+package javalanguser;
+
+public class Toto {
+
+	public String getEchoString(String str) {
+		char[] buffer = new char[17];
+		return new String(buffer);
+	}
+
+}

--- a/app/src/main/java/fr/inria/verveine/extractor/java/VerveineJOptions.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/VerveineJOptions.java
@@ -129,6 +129,11 @@ public class VerveineJOptions {
 	 * Text of comments exported in the model instead of using source anchor
 	 */
 	protected boolean commentText;
+	
+	/**
+	 * Am I parsing a JDK?
+	 */
+	protected boolean parsingJdk = false;
 
 	public VerveineJOptions() {
 		this.allLocals = false;
@@ -243,6 +248,9 @@ public class VerveineJOptions {
 		} else if (arg.equals("-i")) {
 			incrementalParsing = true;
 
+		}
+		else if (arg.equals("-jdkMode")) {
+			parsingJdk = true;
 		}
 		else if (arg.equals("-debugging")) {
 				debugging = true;
@@ -386,6 +394,7 @@ public class VerveineJOptions {
 		System.err.println("      [-filecp FILE] gather all jars listed in FILE (absolute paths) and put them in the classpath");
 		System.err.println("      [-excludepath GLOBBINGEXPR] A globbing expression of file path to exclude from parsing");
 		System.err.println("      [-1.1 | -1 | -1.2 | -2 | ... | -1.7 | -7] specifies version of Java");
+		System.err.println("      [-jdkMode] option to ABSOLUTELY set if you are making a model of a JDK");
 		System.err.println("      <files-to-parse>|<dirs-to-parse> list of source files to parse or directories to search for source files");
 	}
 
@@ -417,7 +426,10 @@ public class VerveineJOptions {
 	}
 
 	public void configureJDTParser(ASTParser jdtParser) {
-		jdtParser.setEnvironment(classPathOptions, /*sourcepathEntries*/argPath.toArray(new String[0]), /*encodings*/null, /*includeRunningVMBootclasspath*/true);
+		// If I am parsing a JDK, jdt must not provide the VM's running libraries (=jdk used by VerveineJ at runtime)
+		boolean includeRunningVMBootclasspath = !parsingJdk;
+		
+		jdtParser.setEnvironment(classPathOptions, /*sourcepathEntries*/argPath.toArray(new String[0]), /*encodings*/null, includeRunningVMBootclasspath);
 		jdtParser.setResolveBindings(true);
 		/**
 		 *  Incremental parsing should not activate Binding recovery because using this option with incremental parsing
@@ -593,6 +605,10 @@ public class VerveineJOptions {
 
 	public boolean commentsAsText() {
 		return commentText;
+	}
+	
+	public boolean isParsingJdk() {
+		return parsingJdk;
 	}
 
 	public String getFileEncoding() {

--- a/app/src/main/java/fr/inria/verveine/extractor/java/VerveineJParser.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/VerveineJParser.java
@@ -79,7 +79,8 @@ public class VerveineJParser {
 					/*requestor*/req,
 					/*monitor*/null);
 		} catch (java.lang.IllegalStateException e) {
-			System.out.println("VerveineJ could not launch parser, received error: " + e.getMessage());
+			System.out.println("VerveineJ could not launch parser");
+			e.printStackTrace();
 		}
 
 		this.compressPackagesNames();

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_JDKImport.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_JDKImport.java
@@ -5,17 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.util.ArrayList;
 
-import org.eclipse.jdt.internal.compiler.batch.Main;
-import org.eclipse.jdt.internal.compiler.env.IModule;
-import org.eclipse.jdt.internal.compiler.batch.FileSystem.Classpath;
-import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.moosetechnology.model.famix.famixjavaentities.Class;
@@ -32,15 +22,6 @@ public class VerveineJTest_JDKImport extends VerveineJTest_Basic {
 		new File(DEFAULT_OUTPUT_FILE).delete();
 		parser = new VerveineJParser();
 		repo = parser.getFamixRepo();
-
-		OutputStreamWriter writer = new FileWriter("resources/java/base/module-info.java");
-		writer.write("module java.base {}");
-		writer.close();
-	}
-
-	@After
-	public void tearDown() throws IOException {
-		new File(("resources/java/base/module-info.java")).delete();
 	}
 
 	@Test

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_JDKImport.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_JDKImport.java
@@ -1,0 +1,140 @@
+package fr.inria.verveine.extractor.java;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+
+import org.eclipse.jdt.internal.compiler.batch.Main;
+import org.eclipse.jdt.internal.compiler.env.IModule;
+import org.eclipse.jdt.internal.compiler.batch.FileSystem.Classpath;
+import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.moosetechnology.model.famix.famixjavaentities.Class;
+import org.moosetechnology.model.famix.famixjavaentities.IndexedFileAnchor;
+import org.moosetechnology.model.famix.famixtraits.TInheritance;
+import org.moosetechnology.model.famix.famixtraits.TInvocable;
+import org.moosetechnology.model.famix.famixtraits.TInvocation;
+import org.moosetechnology.model.famix.famixtraits.TMethod;
+
+public class VerveineJTest_JDKImport extends VerveineJTest_Basic {
+
+	@Before
+	public void setUp() throws Exception {
+		new File(DEFAULT_OUTPUT_FILE).delete();
+		parser = new VerveineJParser();
+		repo = parser.getFamixRepo();
+
+		OutputStreamWriter writer = new FileWriter("resources/java/base/module-info.java");
+		writer.write("module java.base {}");
+		writer.close();
+	}
+
+	@After
+	public void tearDown() throws IOException {
+		new File(("resources/java/base/module-info.java")).delete();
+	}
+
+	@Test
+	public void testReferenceToJavaLangClassIsStubWithoutJDK() {
+
+		parser.configure(new String[] { "resources/javalanguser" });
+		parser.parse();
+
+		Class clazz = detectFamixElement(Class.class, "Toto");
+		TMethod[] methods = clazz.getMethods().toArray(new TMethod[0]);
+		assertEquals(1, methods.length);
+		TInvocation[] outgoingInvocations = methods[0].getOutgoingInvocations().toArray(new TInvocation[0]);
+		TInvocable[] candidates = outgoingInvocations[0].getCandidates().toArray(new TInvocable[0]);
+		Class declaredType = (Class) ((TMethod) candidates[0]).getParentType();
+		assertTrue(declaredType.getIsStub());
+	}
+
+	@Test
+	public void testLoadOurJDKStringClass() {
+
+		parser.configure(new String[] { "resources/java/lang/String.java" });
+		parser.parse();
+
+		Class ourString = detectFamixElement(Class.class, "String");
+		assertFalse(ourString.getIsStub());
+		assertEquals(((IndexedFileAnchor) ourString.getSourceAnchor()).getFileName(),
+				"resources/java/lang/String.java");
+		assertEquals(1, entitiesNamed(Class.class, "String").size());
+	}
+
+	@Test
+	public void testLoadOurJDKObjectClass() {
+
+		parser.configure(new String[] { "resources/java/lang/Object.java" });
+		parser.parse();
+
+		assertEquals(1, entitiesNamed(Class.class, "Object").size());
+		Class ourObject = detectFamixElement(Class.class, "Object");
+		assertFalse(ourObject.getIsStub());
+		assertEquals(((IndexedFileAnchor) ourObject.getSourceAnchor()).getFileName(),
+				"resources/java/lang/Object.java");
+	}
+
+	@Test
+	public void testHasRefToExternalClassLoadingStringFirst() {
+
+		parser.configure(new String[] { "-jdkMode", "-1.7", "resources/java/lang/String.java",
+				"resources/java/lang/Object.java", "resources/javalanguser/Toto.java" });
+		parser.parse();
+
+		assertEquals(1, entitiesNamed(Class.class, "String").size());
+		Class ourString = detectFamixElement(Class.class, "String");
+
+		Class clazz = detectFamixElement(Class.class, "Toto");
+		TMethod[] methods = clazz.getMethods().toArray(new TMethod[0]);
+		assertEquals(1, methods.length);
+		TInvocation[] outgoingInvocations = methods[0].getOutgoingInvocations().toArray(new TInvocation[0]);
+		TInvocable[] candidates = outgoingInvocations[0].getCandidates().toArray(new TInvocable[0]);
+		Class declaredType = (Class) ((TMethod) candidates[0]).getParentType();
+		assertEquals(declaredType, ourString);
+	}
+
+	@Test
+	public void testHasRefToExternalClassLoadingStringSecond() {
+
+		parser.configure(new String[] { "-jdkMode", "-1.7", "resources/javalanguser/Toto.java",
+				"resources/java/lang/String.java", "resources/java/lang/Object.java" });
+		parser.parse();
+
+		assertEquals(1, entitiesNamed(Class.class, "String").size());
+		Class ourString = detectFamixElement(Class.class, "String");
+
+		Class clazz = detectFamixElement(Class.class, "Toto");
+		TMethod[] methods = clazz.getMethods().toArray(new TMethod[0]);
+		assertEquals(1, methods.length);
+		TInvocation[] outgoingInvocations = methods[0].getOutgoingInvocations().toArray(new TInvocation[0]);
+		TInvocable[] candidates = outgoingInvocations[0].getCandidates().toArray(new TInvocable[0]);
+		Class declaredType = (Class) ((TMethod) candidates[0]).getParentType();
+		assertEquals(declaredType, ourString);
+	}
+
+	@Test
+	public void testHasSuperclassRefToOurObject() {
+
+		parser.configure(new String[] { "-jdkMode", "-1.7", "resources/java/lang/String.java",
+				"resources/java/lang/Object.java", "resources/javalanguser/Toto.java" });
+		parser.parse();
+
+		Class ourObject = detectFamixElement(Class.class, "Object");
+
+		Class clazz = detectFamixElement(Class.class, "Toto");
+		TInheritance[] inheritances = clazz.getSuperInheritances().toArray(new TInheritance[0]);
+		assertEquals(1, inheritances.length);
+		Class superclass = (Class) inheritances[0].getSuperclass();
+		assertEquals(superclass, ourObject);
+	}
+}


### PR DESCRIPTION
This PR adds an option on the command line called `-jdkMode` which allows us to parse correctly a JDK.
It must be used with the option to set the compiler compliance, and only if the version is <= 1.8

For versions from 1.9 and above, we must find a way to set up the JDT parser and sources so that it can locate the `java.base` module. We tried to do so for a while but haven't found the solution to that problem yet.