### PR TITLE
Add strict option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ out/
 build
 
 app/bin
+app/.classpath
 gradle.properties

--- a/app/src/main/java/fr/inria/verveine/extractor/java/FamixRequestor.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/FamixRequestor.java
@@ -67,6 +67,12 @@ public class FamixRequestor extends FileASTRequestor {
 			ast.accept(new VisitorExceptionRef(famixDictionnary, options));
 
 		} catch (Exception err) {
+			
+			if (options.isStrict())
+			{
+				throw err;
+			}
+			
 			err.printStackTrace();
 			System.err.println("*** " + getVisitorName(err, path) + " got exception: '" + err + "' while processing file: " + path);
 		}

--- a/app/src/main/java/fr/inria/verveine/extractor/java/VerveineJOptions.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/VerveineJOptions.java
@@ -158,6 +158,11 @@ public class VerveineJOptions {
 	 */
 	protected boolean parsingJdk = false;
 
+	/**
+	 * Option: Whether to put SourceAnchors in the entities and/or associations
+	 */
+	private boolean isStrict = false;
+
 	public VerveineJOptions() {
 		this.allLocals = false;
 		this.codeVers = null;
@@ -274,6 +279,9 @@ public class VerveineJOptions {
 		}
 		else if (arg.equals("-jdkMode")) {
 			parsingJdk = true;
+		}
+		else if (arg.equals("-strict")) {
+			isStrict = true;
 		}
 		else if (arg.equals("-debugging")) {
 			debugging = true;
@@ -624,6 +632,10 @@ public class VerveineJOptions {
 
 	public String getFileEncoding() {
 		return fileEncoding;
+	}
+	
+	public boolean isStrict() {
+		return isStrict;
 	}
 
 }

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_Configuration.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_Configuration.java
@@ -364,5 +364,21 @@ public class VerveineJTest_Configuration extends VerveineJTest_Basic {
 		};
 		assertThrows(IllegalArgumentException.class, () -> parser.configure(args));
 	}
+	
+	@Test
+	public void testStrictModeIsFalseByDefault() {
+		VerveineJOptions options = new VerveineJOptions();
+		assertFalse(options.isStrict());
+	}
 
+	@Test
+	public void testStrictModeTrueWhenSet() {
+		String[] args = new String[] {
+				"-strict"
+			};
+		VerveineJOptions options = new VerveineJOptions();
+		options.setOptions(args);
+		assertTrue(options.isStrict());
+	}
+	
 }


### PR DESCRIPTION
If a VVJ visitor fails, stop the process instead of printing error and continue.
This is governed by a setting, which is false by default to be backward compatible.