### PR TITLE
Add support for primitive types in generics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ out/
 build
 
 app/bin
+app/.classpath
 gradle.properties

--- a/app/src/main/java/fr/inria/verveine/extractor/java/EntityDictionary.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/EntityDictionary.java
@@ -461,7 +461,15 @@ public class EntityDictionary {
 		Iterator<ITypeBinding> concreteIterator = Arrays.asList(typeArguments).iterator();
 
 		while (concreteIterator.hasNext() && genericIterator.hasNext()) {
-			TTypeArgument typeArgument = (TTypeArgument)ensureFamixType(concreteIterator.next());
+			
+			TTypeArgument typeArgument;
+			try {
+				typeArgument = (TTypeArgument)ensureFamixType(concreteIterator.next());
+			} catch(ClassCastException e) {
+				
+				throw e;
+			}
+			
 			TypeParameter typeParameter = (TypeParameter)ensureFamixType(genericIterator.next());
 
 			Concretization concretization = ensureFamixConcretization(typeArgument, typeParameter);

--- a/app/src/main/java/fr/inria/verveine/extractor/java/EntityDictionary.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/EntityDictionary.java
@@ -462,14 +462,7 @@ public class EntityDictionary {
 
 		while (concreteIterator.hasNext() && genericIterator.hasNext()) {
 			
-			TTypeArgument typeArgument;
-			try {
-				typeArgument = (TTypeArgument)ensureFamixType(concreteIterator.next());
-			} catch(ClassCastException e) {
-				
-				throw e;
-			}
-			
+			TTypeArgument typeArgument = (TTypeArgument)ensureFamixType(concreteIterator.next());			
 			TypeParameter typeParameter = (TypeParameter)ensureFamixType(genericIterator.next());
 
 			Concretization concretization = ensureFamixConcretization(typeArgument, typeParameter);
@@ -941,6 +934,7 @@ public class EntityDictionary {
 
 		if (bnd.isArray()) {
 			bnd = bnd.getElementType();
+			//return this.ensureFamixArrayOf(bnd);
 		}
 
 		if (bnd.isPrimitive()) {
@@ -1024,6 +1018,30 @@ public class EntityDictionary {
 			return isThrowable(bnd.getSuperclass());
 		}
 	}
+	
+	/***
+	 * Create an entity representing an array type.
+	 * This covers arrays to reference (Class[]) and primitive types (int[])
+	 * 
+	 * Array types are represented as Parametric types: 
+	 * 	Array<T> where T is any type
+	 *  For example, Array<Object> or Array<int>
+	 *   
+	 * Now, Array is not a proper class in the JDK.
+	 * In Java, arrays are objects of an anonymous class, subclass of Object.
+	 * For our purposes, we represent them by doing the following:
+	 *  - we create an artificial parametric class named Array, subclass of java.lang.Object
+	 *  - we create a concretization of that class, binding the type parameter to the array element type
+	 * 
+	 * @param bnd, a JDT resolved type
+	 * @return a concretization of Array<T> with T bound to the array element type
+	 */
+	//private Type ensureFamixArrayOf(ITypeBinding bnd) {
+//		ParametricClass arrayClass = this.ensureFamixParametricArrayClass();
+//		
+//		Concretization concretization = ensureFamixConcretization(arrayClass, bnd.getElementType());
+//		return concretization;
+//	}
 
 	/**
 	 * Returns a Famix Class associated with the ITypeBinding.

--- a/app/src/main/java/fr/inria/verveine/extractor/java/FamixRequestor.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/FamixRequestor.java
@@ -67,6 +67,12 @@ public class FamixRequestor extends FileASTRequestor {
 			ast.accept(new VisitorExceptionRef(famixDictionnary, options));
 
 		} catch (Exception err) {
+			
+			if (options.isStrict())
+			{
+				throw err;
+			}
+			
 			err.printStackTrace();
 			System.err.println("*** " + getVisitorName(err, path) + " got exception: '" + err + "' while processing file: " + path);
 		}

--- a/app/src/main/java/fr/inria/verveine/extractor/java/VerveineJOptions.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/VerveineJOptions.java
@@ -158,6 +158,11 @@ public class VerveineJOptions {
 	 */
 	protected boolean parsingJdk = false;
 
+	/**
+	 * Option: Whether to put SourceAnchors in the entities and/or associations
+	 */
+	private boolean isStrict = false;
+
 	public VerveineJOptions() {
 		this.allLocals = false;
 		this.codeVers = null;
@@ -274,6 +279,9 @@ public class VerveineJOptions {
 		}
 		else if (arg.equals("-jdkMode")) {
 			parsingJdk = true;
+		}
+		else if (arg.equals("-strict")) {
+			isStrict = true;
 		}
 		else if (arg.equals("-debugging")) {
 			debugging = true;
@@ -624,6 +632,10 @@ public class VerveineJOptions {
 
 	public String getFileEncoding() {
 		return fileEncoding;
+	}
+	
+	public boolean isStrict() {
+		return isStrict;
 	}
 
 }

--- a/app/src/main/java/org/moosetechnology/model/famix/famixjavaentities/PrimitiveType.java
+++ b/app/src/main/java/org/moosetechnology/model/famix/famixjavaentities/PrimitiveType.java
@@ -6,16 +6,20 @@ import ch.akuhn.fame.FamePackage;
 import ch.akuhn.fame.FameProperty;
 import ch.akuhn.fame.internal.MultivalueSet;
 import java.util.*;
+
+import org.moosetechnology.model.famix.famixjavaentities.Class;
+import org.moosetechnology.model.famix.famixtraits.TConcretization;
 import org.moosetechnology.model.famix.famixtraits.TEntityTyping;
 import org.moosetechnology.model.famix.famixtraits.TPrimitiveType;
 import org.moosetechnology.model.famix.famixtraits.TReference;
 import org.moosetechnology.model.famix.famixtraits.TSourceAnchor;
+import org.moosetechnology.model.famix.famixtraits.TTypeArgument;
 import org.moosetechnology.model.famix.famixtraits.TWithTypes;
 
 
 @FamePackage("Famix-Java-Entities")
 @FameDescription("PrimitiveType")
-public class PrimitiveType extends Type implements TPrimitiveType {
+public class PrimitiveType extends Type implements TPrimitiveType, TTypeArgument {
 
     private Collection<TReference> incomingReferences; 
 
@@ -30,6 +34,8 @@ public class PrimitiveType extends Type implements TPrimitiveType {
     private TSourceAnchor sourceAnchor;
     
     private TWithTypes typeContainer;
+
+	private Collection<TConcretization> outgoingConcretizations;
     
 
 
@@ -262,7 +268,57 @@ public class PrimitiveType extends Type implements TPrimitiveType {
         if (typeContainer == null) return;
         typeContainer.getTypes().add(this);
     }
+
+    @FameProperty(name = "outgoingConcretizations", opposite = "typeArgument", derived = true)
+    public Collection<TConcretization> getOutgoingConcretizations() {
+        if (outgoingConcretizations == null) {
+            outgoingConcretizations = new MultivalueSet<TConcretization>() {
+                @Override
+                protected void clearOpposite(TConcretization e) {
+                    e.setTypeArgument(null);
+                }
+                @Override
+                protected void setOpposite(TConcretization e) {
+                    e.setTypeArgument(PrimitiveType.this);
+                }
+            };
+        }
+        return outgoingConcretizations;
+    }
     
+    public void setOutgoingConcretizations(Collection<? extends TConcretization> outgoingConcretizations) {
+        this.getOutgoingConcretizations().clear();
+        this.getOutgoingConcretizations().addAll(outgoingConcretizations);
+    }                    
+    
+        
+    public void addOutgoingConcretizations(TConcretization one) {
+        this.getOutgoingConcretizations().add(one);
+    }   
+    
+    public void addOutgoingConcretizations(TConcretization one, TConcretization... many) {
+        this.getOutgoingConcretizations().add(one);
+        for (TConcretization each : many)
+            this.getOutgoingConcretizations().add(each);
+    }   
+    
+    public void addOutgoingConcretizations(Iterable<? extends TConcretization> many) {
+        for (TConcretization each : many)
+            this.getOutgoingConcretizations().add(each);
+    }   
+                
+    public void addOutgoingConcretizations(TConcretization[] many) {
+        for (TConcretization each : many)
+            this.getOutgoingConcretizations().add(each);
+    }
+    
+    public int numberOfOutgoingConcretizations() {
+        return getOutgoingConcretizations().size();
+    }
+
+    public boolean hasOutgoingConcretizations() {
+        return !getOutgoingConcretizations().isEmpty();
+    }
 
 
 }

--- a/app/src/main/java/org/moosetechnology/model/famix/famixjavaentities/PrimitiveType.java
+++ b/app/src/main/java/org/moosetechnology/model/famix/famixjavaentities/PrimitiveType.java
@@ -6,20 +6,16 @@ import ch.akuhn.fame.FamePackage;
 import ch.akuhn.fame.FameProperty;
 import ch.akuhn.fame.internal.MultivalueSet;
 import java.util.*;
-
-import org.moosetechnology.model.famix.famixjavaentities.Class;
-import org.moosetechnology.model.famix.famixtraits.TConcretization;
 import org.moosetechnology.model.famix.famixtraits.TEntityTyping;
 import org.moosetechnology.model.famix.famixtraits.TPrimitiveType;
 import org.moosetechnology.model.famix.famixtraits.TReference;
 import org.moosetechnology.model.famix.famixtraits.TSourceAnchor;
-import org.moosetechnology.model.famix.famixtraits.TTypeArgument;
 import org.moosetechnology.model.famix.famixtraits.TWithTypes;
 
 
 @FamePackage("Famix-Java-Entities")
 @FameDescription("PrimitiveType")
-public class PrimitiveType extends Type implements TPrimitiveType, TTypeArgument {
+public class PrimitiveType extends Type implements TPrimitiveType {
 
     private Collection<TReference> incomingReferences; 
 
@@ -34,8 +30,6 @@ public class PrimitiveType extends Type implements TPrimitiveType, TTypeArgument
     private TSourceAnchor sourceAnchor;
     
     private TWithTypes typeContainer;
-
-	private Collection<TConcretization> outgoingConcretizations;
     
 
 
@@ -268,57 +262,7 @@ public class PrimitiveType extends Type implements TPrimitiveType, TTypeArgument
         if (typeContainer == null) return;
         typeContainer.getTypes().add(this);
     }
-
-    @FameProperty(name = "outgoingConcretizations", opposite = "typeArgument", derived = true)
-    public Collection<TConcretization> getOutgoingConcretizations() {
-        if (outgoingConcretizations == null) {
-            outgoingConcretizations = new MultivalueSet<TConcretization>() {
-                @Override
-                protected void clearOpposite(TConcretization e) {
-                    e.setTypeArgument(null);
-                }
-                @Override
-                protected void setOpposite(TConcretization e) {
-                    e.setTypeArgument(PrimitiveType.this);
-                }
-            };
-        }
-        return outgoingConcretizations;
-    }
     
-    public void setOutgoingConcretizations(Collection<? extends TConcretization> outgoingConcretizations) {
-        this.getOutgoingConcretizations().clear();
-        this.getOutgoingConcretizations().addAll(outgoingConcretizations);
-    }                    
-    
-        
-    public void addOutgoingConcretizations(TConcretization one) {
-        this.getOutgoingConcretizations().add(one);
-    }   
-    
-    public void addOutgoingConcretizations(TConcretization one, TConcretization... many) {
-        this.getOutgoingConcretizations().add(one);
-        for (TConcretization each : many)
-            this.getOutgoingConcretizations().add(each);
-    }   
-    
-    public void addOutgoingConcretizations(Iterable<? extends TConcretization> many) {
-        for (TConcretization each : many)
-            this.getOutgoingConcretizations().add(each);
-    }   
-                
-    public void addOutgoingConcretizations(TConcretization[] many) {
-        for (TConcretization each : many)
-            this.getOutgoingConcretizations().add(each);
-    }
-    
-    public int numberOfOutgoingConcretizations() {
-        return getOutgoingConcretizations().size();
-    }
-
-    public boolean hasOutgoingConcretizations() {
-        return !getOutgoingConcretizations().isEmpty();
-    }
 
 
 }

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_ArrayTypes.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_ArrayTypes.java
@@ -1,0 +1,84 @@
+package fr.inria.verveine.extractor.java;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.Exception;
+import java.util.Collection;
+import java.util.Hashtable;
+import java.util.Iterator;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.moosetechnology.model.famix.famixjavaentities.*;
+import org.moosetechnology.model.famix.famixjavaentities.Class;
+import org.moosetechnology.model.famix.famixtraits.*;
+
+public class VerveineJTest_ArrayTypes extends VerveineJTest_Basic {
+
+    @Test
+    public void testConcretizePrimitiveArray(){
+    	
+    	parser = new VerveineJParser();
+        repo = parser.getFamixRepo();
+        parser.configure(new String[] { 
+        		"src/test/resources/generics/UsingPrimitiveArrayConcretization.java",
+        		"src/test/resources/generics/Nicolas.java",
+        		"src/test/resources/generics/OneGenericClass.java",
+        		"src/test/resources/generics/TwoGenericClass.java"});
+        parser.parse();
+        parser.exportModel();
+    	
+    	Attribute attribute = detectFamixElement(Attribute.class, "attributeUsingPrimitiveArrayConcretization");
+    	
+    	Collection<TConcretization> concretizations = ((ParametricEntityTyping)attribute.getTyping()).getConcretizations();
+    	assertEquals(1, concretizations.size());
+    	
+    	TConcretization theConcretization = this.firstElt(concretizations);
+    	assertTrue(theConcretization.getTypeArgument() instanceof PrimitiveType);
+    	
+    	assertEquals("int", ((PrimitiveType) theConcretization.getTypeArgument()).getName());
+    }
+    
+    @Test
+    public void testConcretizePrimitiveArrayMixedWithRef(){
+    	
+    	Attribute attribute = detectFamixElement(Attribute.class, "attributeMixingPrimitiveArrayConcretizationWithRef");
+    	
+    	Collection<TConcretization> concretizations = ((ParametricEntityTyping)attribute.getTyping()).getConcretizations();
+    	assertEquals(2, concretizations.size());
+    	
+    	TConcretization theConcretization = this.elementAt(concretizations, 1);
+    	assertTrue(theConcretization.getTypeArgument() instanceof PrimitiveType);
+    	
+    	assertEquals("int", ((PrimitiveType) theConcretization.getTypeArgument()).getName());
+ 
+    }
+
+    // UTILITIES --------------------------------------------------
+
+    /*
+     * private Collection<java.lang.Class<?>> allInterfaces() {
+     * Set<java.lang.Class<?>> allInterfaces = (Set<java.lang.Class<?>>)
+     * allInterfacesFromClasses(JAVA_CLASSES_USED);
+     * 
+     * for (java.lang.Class<?> javaClass : JAVA_INTERFACES_USED) {
+     * allInterfaces.addAll( allJavaInterfaces( javaClass).flattenToCollection());
+     * }
+     * 
+     * return allInterfaces;
+     * }
+     * 
+     * private Stream<java.lang.Class<?>> allParameterizedInterfaces() {
+     * return allInterfaces().stream().filter( (e) -> e.getTypeParameters().length >
+     * 0);
+     * }
+     * 
+     * private Stream<java.lang.Class<?>> allParameterizedClasses() {
+     * return allJavaSuperClasses(JAVA_CLASSES_USED).stream().filter( (e) ->
+     * e.getTypeParameters().length > 0);
+     * }
+     */
+}

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_Configuration.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_Configuration.java
@@ -364,5 +364,21 @@ public class VerveineJTest_Configuration extends VerveineJTest_Basic {
 		};
 		assertThrows(IllegalArgumentException.class, () -> parser.configure(args));
 	}
+	
+	@Test
+	public void testStrictModeIsFalseByDefault() {
+		VerveineJOptions options = new VerveineJOptions();
+		assertFalse(options.isStrict());
+	}
 
+	@Test
+	public void testStrictModeTrueWhenSet() {
+		String[] args = new String[] {
+				"-strict"
+			};
+		VerveineJOptions options = new VerveineJOptions();
+		options.setOptions(args);
+		assertTrue(options.isStrict());
+	}
+	
 }

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_Generics.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_Generics.java
@@ -405,35 +405,6 @@ public class VerveineJTest_Generics extends VerveineJTest_Basic {
         	);
         }
     }
-    
-    @Test
-    public void testConcretizePrimitiveArray(){
-    	
-    	Attribute attribute = detectFamixElement(Attribute.class, "attributeUsingPrimitiveArrayConcretization");
-    	
-    	Collection<TConcretization> concretizations = ((ParametricEntityTyping)attribute.getTyping()).getConcretizations();
-    	assertEquals(1, concretizations.size());
-    	
-    	TConcretization theConcretization = this.firstElt(concretizations);
-    	assertTrue(theConcretization.getTypeArgument() instanceof PrimitiveType);
-    	
-    	assertEquals("int", ((PrimitiveType) theConcretization.getTypeArgument()).getName());
-    }
-    
-    @Test
-    public void testConcretizePrimitiveArrayMixedWithRef(){
-    	
-    	Attribute attribute = detectFamixElement(Attribute.class, "attributeMixingPrimitiveArrayConcretizationWithRef");
-    	
-    	Collection<TConcretization> concretizations = ((ParametricEntityTyping)attribute.getTyping()).getConcretizations();
-    	assertEquals(2, concretizations.size());
-    	
-    	TConcretization theConcretization = this.elementAt(concretizations, 1);
-    	assertTrue(theConcretization.getTypeArgument() instanceof PrimitiveType);
-    	
-    	assertEquals("int", ((PrimitiveType) theConcretization.getTypeArgument()).getName());
- 
-    }
 
     // UTILITIES --------------------------------------------------
 

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_Generics.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_Generics.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.lang.Exception;
 import java.util.Collection;
+import java.util.Hashtable;
 import java.util.Iterator;
 
 import org.junit.Before;
@@ -403,6 +404,35 @@ public class VerveineJTest_Generics extends VerveineJTest_Basic {
             	inv.getSignature().equals("copyOf(delegates)")
         	);
         }
+    }
+    
+    @Test
+    public void testConcretizePrimitiveArray(){
+    	
+    	Attribute attribute = detectFamixElement(Attribute.class, "attributeUsingPrimitiveArrayConcretization");
+    	
+    	Collection<TConcretization> concretizations = ((ParametricEntityTyping)attribute.getTyping()).getConcretizations();
+    	assertEquals(1, concretizations.size());
+    	
+    	TConcretization theConcretization = this.firstElt(concretizations);
+    	assertTrue(theConcretization.getTypeArgument() instanceof PrimitiveType);
+    	
+    	assertEquals("int", ((PrimitiveType) theConcretization.getTypeArgument()).getName());
+    }
+    
+    @Test
+    public void testConcretizePrimitiveArrayMixedWithRef(){
+    	
+    	Attribute attribute = detectFamixElement(Attribute.class, "attributeMixingPrimitiveArrayConcretizationWithRef");
+    	
+    	Collection<TConcretization> concretizations = ((ParametricEntityTyping)attribute.getTyping()).getConcretizations();
+    	assertEquals(2, concretizations.size());
+    	
+    	TConcretization theConcretization = this.elementAt(concretizations, 1);
+    	assertTrue(theConcretization.getTypeArgument() instanceof PrimitiveType);
+    	
+    	assertEquals("int", ((PrimitiveType) theConcretization.getTypeArgument()).getName());
+ 
     }
 
     // UTILITIES --------------------------------------------------

--- a/app/src/test/resources/generics/Nicolas.java
+++ b/app/src/test/resources/generics/Nicolas.java
@@ -1,0 +1,6 @@
+package generics;
+
+public class Nicolas <T> {
+
+	Nicolas<Nicolas<Integer>> attr;
+}

--- a/app/src/test/resources/generics/OneGenericClass.java
+++ b/app/src/test/resources/generics/OneGenericClass.java
@@ -1,0 +1,5 @@
+package generics;
+
+public class OneGenericClass<T> {
+
+}

--- a/app/src/test/resources/generics/TwoGenericClass.java
+++ b/app/src/test/resources/generics/TwoGenericClass.java
@@ -1,0 +1,5 @@
+package generics;
+
+public class TwoGenericClass<T,U> {
+
+}

--- a/app/src/test/resources/generics/UsingPrimitiveArrayConcretization.java
+++ b/app/src/test/resources/generics/UsingPrimitiveArrayConcretization.java
@@ -1,8 +1,8 @@
 package generics;
 
-public class UsingPrimitiveArrayConcretization {
+public class UsingPrimitiveArrayConcretization extends Nicolas<UsingPrimitiveArrayConcretization> {
 
-	private static final OneGenericClass<int[]> attributeUsingPrimitiveArrayConcretization = new OneGenericClass<int[]>();
+//	private static final OneGenericClass<int[]> attributeUsingPrimitiveArrayConcretization = new OneGenericClass<int[]>();
 	
-	private static final TwoGenericClass<UsingPrimitiveArrayConcretization, int[]> attributeMixingPrimitiveArrayConcretizationWithRef = new TwoGenericClass<UsingPrimitiveArrayConcretization, int[]>();
+//	private static final TwoGenericClass<UsingPrimitiveArrayConcretization, int[]> attributeMixingPrimitiveArrayConcretizationWithRef = new TwoGenericClass<UsingPrimitiveArrayConcretization, int[]>();
 }

--- a/app/src/test/resources/generics/UsingPrimitiveArrayConcretization.java
+++ b/app/src/test/resources/generics/UsingPrimitiveArrayConcretization.java
@@ -1,0 +1,8 @@
+package generics;
+
+public class UsingPrimitiveArrayConcretization {
+
+	private static final OneGenericClass<int[]> attributeUsingPrimitiveArrayConcretization = new OneGenericClass<int[]>();
+	
+	private static final TwoGenericClass<UsingPrimitiveArrayConcretization, int[]> attributeMixingPrimitiveArrayConcretizationWithRef = new TwoGenericClass<UsingPrimitiveArrayConcretization, int[]>();
+}


### PR DESCRIPTION
This is a draft.
 - sketch support for primitive types (and arrays of primitive types) in type concretizations
 - add tests

We are discussing about extending the meta-model to represent arrays.