### PR TITLE
Fix Interface methods default attributes

### DIFF
--- a/app/src/main/java/fr/inria/verveine/extractor/java/EntityDictionary.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/EntityDictionary.java
@@ -1106,7 +1106,7 @@ public class EntityDictionary {
 		if (fmx!=null) {
 			// we just created it, or it was not bound so we make sure it has the right information in it
 			if (bnd != null) {
-				setClassModifiers(fmx, bnd.getDeclaredModifiers());
+				setClassModifiers(fmx, bnd.getDeclaredModifiers(), (TWithTypes) owner);
 			}
 
 			TAssociation lastAssoc = null;
@@ -1465,7 +1465,7 @@ public class EntityDictionary {
 		}
 
 		if (bnd != null) {
-			setVisibility(fmx, bnd.getModifiers());
+			setVisibility(fmx, bnd.getModifiers(), owner);
 		}
 
 		return fmx;
@@ -2459,28 +2459,28 @@ public class EntityDictionary {
 	}
 
 	public void setAttributeModifiers(Attribute fmx, int mod) {
-		setCommonModifiers(fmx, mod);
+		setCommonModifiers(fmx, mod, null);
 		fmx.setIsTransient(Modifier.isTransient(mod));
 		fmx.setIsVolatile(Modifier.isVolatile(mod));
 	}
 
 	public void setMethodModifiers(Method fmx, int mod) {
-		setCommonModifiers(fmx, mod);
+		setCommonModifiers(fmx, mod, (TWithTypes) fmx.getParentType());
 		fmx.setIsAbstract(Modifier.isAbstract(mod));
 		fmx.setIsSynchronized(Modifier.isSynchronized(mod));
 	}
 
-	public void setClassModifiers(Class fmx, int mod) {
-		setCommonModifiers(fmx, mod);
+	public void setClassModifiers(Class fmx, int mod, TWithTypes owner) {
+		setCommonModifiers(fmx, mod, null);
 		fmx.setIsAbstract(Modifier.isAbstract(mod));
 	}
 
 	public void setInterfaceModifiers(Interface fmx, int mod) {
-		setCommonModifiers(fmx, mod);
+		setCommonModifiers(fmx, mod, null);
 	}
 
-	private void setCommonModifiers(Entity fmx, int mod) {
-		setVisibility((THasVisibility)fmx, mod);
+	private void setCommonModifiers(Entity fmx, int mod, TWithTypes owner) {
+		setVisibility((THasVisibility)fmx, mod, owner);
 		((TCanBeClassSide)fmx).setIsClassSide(Modifier.isStatic(mod));
 		((TCanBeFinal)fmx).setIsFinal(Modifier.isFinal(mod));
 	}
@@ -2491,7 +2491,7 @@ public class EntityDictionary {
 	 * @param fmx -- the FamixNamedEntity
 	 * @param mod -- a description of the modifiers as understood by org.eclipse.jdt.core.dom.Modifier
 	 */
-	public void setVisibility(THasVisibility fmx, int mod) {
+	public void setVisibility(THasVisibility fmx, int mod, TWithTypes owner) {
 		if (Modifier.isPublic(mod)) {
 			fmx.setVisibility(MODIFIER_PUBLIC);
 		} else if (Modifier.isPrivate(mod)) {
@@ -2499,7 +2499,13 @@ public class EntityDictionary {
 		} else if (Modifier.isProtected(mod)) {
 			fmx.setVisibility(MODIFIER_PROTECTED);
 		} else {
-			fmx.setVisibility(MODIFIER_PACKAGE);
+			//Default visibility!
+			//If we are in an interface, default visibility is public, otherwise package.
+			if (owner instanceof Interface) {
+				fmx.setVisibility(MODIFIER_PUBLIC);
+			} else {
+				fmx.setVisibility(MODIFIER_PACKAGE);
+			}
 		}
 	}
 

--- a/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorClassMethodDef.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorClassMethodDef.java
@@ -275,6 +275,10 @@ public class VisitorClassMethodDef extends GetVisitedEntityAbstractVisitor {
 
 			if (node.getBody() != null) {
 				context.setTopMethodCyclo(1);
+			} else {
+				// In interfaces you don't need to explicitly define the method as abstract
+				// However, if they don't have a body, they are!
+				fmx.setIsAbstract(true);
 			}
 			return super.visit(node);
 		} else {

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_ClassProperties.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_ClassProperties.java
@@ -1,5 +1,6 @@
 package fr.inria.verveine.extractor.java;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -39,6 +40,39 @@ public class VerveineJTest_ClassProperties extends VerveineJTest_Basic {
 		
 		Method sizeMethod = detectFamixElement(Method.class, "methodWithBody");
 		assertFalse(sizeMethod.getIsAbstract());
+	}
+	
+	@Test
+	public void testImplicitAbstractInterfaceMethodDefaultVisibilityIsPublic() {
+		parser = new VerveineJParser();
+		repo = parser.getFamixRepo();
+		parser.configure(new String[] { "src/test/resources/classproperties/Collection.java" });
+		parser.parse();
+		
+		Method sizeMethod = detectFamixElement(Method.class, "implicitAbstractMethod");
+		assertEquals("public", sizeMethod.getVisibility());
+	}
+	
+	@Test
+	public void testExplicitAbstractInterfaceMethodDefaultVisibilityIsPublic() {
+		parser = new VerveineJParser();
+		repo = parser.getFamixRepo();
+		parser.configure(new String[] { "src/test/resources/classproperties/Collection.java" });
+		parser.parse();
+		
+		Method sizeMethod = detectFamixElement(Method.class, "explicitAbstractMethod");
+		assertEquals("public", sizeMethod.getVisibility());
+	}
+	
+	@Test
+	public void testInterfaceMethodWithBodyDefaultVisibilityIsPublic() {
+		parser = new VerveineJParser();
+		repo = parser.getFamixRepo();
+		parser.configure(new String[] { "src/test/resources/classproperties/Collection.java" });
+		parser.parse();
+		
+		Method sizeMethod = detectFamixElement(Method.class, "methodWithBody");
+		assertEquals("public", sizeMethod.getVisibility());
 	}
 
 }

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_ClassProperties.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_ClassProperties.java
@@ -1,26 +1,44 @@
 package fr.inria.verveine.extractor.java;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
-import org.moosetechnology.model.famix.famixjavaentities.Interface;
 import org.moosetechnology.model.famix.famixjavaentities.Method;
-
-import ch.akuhn.fame.Repository;
 
 public class VerveineJTest_ClassProperties extends VerveineJTest_Basic {
 
 	@Test
-	public void testAbstractInterfaceMethodIsAbstract() {
+	public void testImplicitAbstractInterfaceMethodIsAbstract() {
 		parser = new VerveineJParser();
 		repo = parser.getFamixRepo();
 		parser.configure(new String[] { "src/test/resources/classproperties/Collection.java" });
 		parser.parse();
 		
-		Interface collectionInterface = detectFamixElement(Interface.class, "Collection");
-		Method sizeMethod = (Method)collectionInterface.getMethods().iterator().next();
+		Method sizeMethod = detectFamixElement(Method.class, "implicitAbstractMethod");
 		assertTrue(sizeMethod.getIsAbstract());
-
+	}
+	
+	@Test
+	public void testExplicitAbstractInterfaceMethodIsAbstract() {
+		parser = new VerveineJParser();
+		repo = parser.getFamixRepo();
+		parser.configure(new String[] { "src/test/resources/classproperties/Collection.java" });
+		parser.parse();
+		
+		Method sizeMethod = detectFamixElement(Method.class, "explicitAbstractMethod");
+		assertTrue(sizeMethod.getIsAbstract());
+	}
+	
+	@Test
+	public void testInterfaceMethodWithBodyIsNotAbstract() {
+		parser = new VerveineJParser();
+		repo = parser.getFamixRepo();
+		parser.configure(new String[] { "src/test/resources/classproperties/Collection.java" });
+		parser.parse();
+		
+		Method sizeMethod = detectFamixElement(Method.class, "methodWithBody");
+		assertFalse(sizeMethod.getIsAbstract());
 	}
 
 }

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_ClassProperties.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_ClassProperties.java
@@ -1,0 +1,26 @@
+package fr.inria.verveine.extractor.java;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.moosetechnology.model.famix.famixjavaentities.Interface;
+import org.moosetechnology.model.famix.famixjavaentities.Method;
+
+import ch.akuhn.fame.Repository;
+
+public class VerveineJTest_ClassProperties extends VerveineJTest_Basic {
+
+	@Test
+	public void testAbstractInterfaceMethodIsAbstract() {
+		parser = new VerveineJParser();
+		repo = parser.getFamixRepo();
+		parser.configure(new String[] { "src/test/resources/classproperties/Collection.java" });
+		parser.parse();
+		
+		Interface collectionInterface = detectFamixElement(Interface.class, "Collection");
+		Method sizeMethod = (Method)collectionInterface.getMethods().iterator().next();
+		assertTrue(sizeMethod.getIsAbstract());
+
+	}
+
+}

--- a/app/src/test/resources/classproperties/Collection.java
+++ b/app/src/test/resources/classproperties/Collection.java
@@ -4,6 +4,13 @@ package classproperties;
 public interface Collection {
 
 	//Just an abstract method here 
-	int size();
-    
+	int implicitAbstractMethod();
+	
+	//Just an abstract method here, but explicit 
+	abstract int explicitAbstractMethod();
+
+	// Method with body! 
+	public default int methodWithBody() {
+		return 0;
+	}
 }

--- a/app/src/test/resources/classproperties/Collection.java
+++ b/app/src/test/resources/classproperties/Collection.java
@@ -10,7 +10,7 @@ public interface Collection {
 	abstract int explicitAbstractMethod();
 
 	// Method with body! 
-	public default int methodWithBody() {
+	default int methodWithBody() {
 		return 0;
 	}
 }

--- a/app/src/test/resources/classproperties/Collection.java
+++ b/app/src/test/resources/classproperties/Collection.java
@@ -1,0 +1,9 @@
+package classproperties;
+
+
+public interface Collection {
+
+	//Just an abstract method here 
+	int size();
+    
+}


### PR DESCRIPTION
Interface methods are not properly marked as abstract or public.
Differently from abstract classes, interfaces can have empty methods, working as abstract method declarations, even though they are not explicitly marked as abstract. Moreover, even though java now allows `private` interface methods, by default they are public. An example as follows:

```java
public interface Collection {

	//Just an abstract method here 
	int implicitAbstractMethod();
	
	//Just an abstract method here, but explicit 
	abstract int explicitAbstractMethod();

	// Method with body! 
	default int methodWithBody() {
		return 0;
	}
}
```

In this case, the first two methods should be marked as abstract, the third not.
All of them are public

Now, the current version 
- looks at the `abstract` keyword, only identifying the second one!
- treats interfaces like classes for the default visibility, marking them as package