### PR TITLE
Avoid confusing constructors

### DIFF
--- a/app/src/main/java/fr/inria/verveine/extractor/java/EntityDictionary.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/EntityDictionary.java
@@ -2426,19 +2426,6 @@ public class EntityDictionary {
 	public Initializer ensureImplicitConstructor(TWithMethods owner, String name, Collection<String> parameterTypesNames) {
 		Initializer fmx = null;
 
-		if (owner != null) {
-			Optional<TMethod> existingInitializer = owner.getMethods().stream()
-					.filter(meth ->
-							((Method) meth).getIsInitializer() &&
-									((Method) meth).getIsConstructor()
-									&& meth.getParameters().size() == parameterTypesNames.size()
-									&& (parameterTypesNames.stream().allMatch(parameterName -> meth.getSignature().contains(parameterName))) )
-					.findFirst();
-			if (existingInitializer.isPresent()) {
-				fmx = (Initializer) existingInitializer.get();
-			}
-		}
-
 		if (fmx == null) {
 			fmx = ensureFamixEntity(Initializer.class, null, name);
 			fmx.setParentType(owner);

--- a/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorClassMethodDef.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorClassMethodDef.java
@@ -310,8 +310,6 @@ public class VisitorClassMethodDef extends GetVisitedEntityAbstractVisitor {
      */
     @Override
 	public boolean visit(Initializer node) {
-		//		System.err.println("TRACE, Visiting Initializer: ");
-
 		Method fmx = (Method) createInitBlock(Modifier.isStatic(node.getModifiers()), true);
 		// init-block don't have return type so no need to create a reference from this class to the "declared return type" class when classSummary is TRUE
 		// also no parameters specified here, so no references to create either

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_Initializers.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_Initializers.java
@@ -9,84 +9,46 @@ import org.moosetechnology.model.famix.famixtraits.TMethod;
 
 import java.lang.Exception;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.function.Predicate;
 
 import static org.junit.Assert.*;
 
 public class VerveineJTest_Initializers extends VerveineJTest_Basic {
 
-    @Before
-    public void setUp() throws Exception {
-        parser = new VerveineJParser();
-        repo = parser.getFamixRepo();
-        parser.configure( new String[] {"src/test/resources/initializers"});
-        parser.parse();
-    }
+   	private void parse(String path) {
+   		parse(new String[] {path});
+	}
 
+	private void parse(String[] args) {
+		parser = new VerveineJParser();
+        repo = parser.getFamixRepo();
+		parser.configure( args);
+        parser.parse();
+	}
 
     @Test
     public void testNumberOfMethods() {
+    	
+    	parse("src/test/resources/initializers");
+    	
         Collection<Method> methods = entitiesOfType(Method.class);
-        /*
-        In class SuperClassWithImplicitConstructor: 1
-            SuperClassWithImplicitConstructor(), the implicit constructor
 
-        In class SuperclassWithConstructor: 3
-            <Initializer>
-            SuperclassWithConstructor()
-            initializeFromSuperAttributeDefinition()
-
-        In class ClassWithInitializers: 14
-            - Initializers (4):
-                Static <Initializer> = Static attribute definitions
-                Static initialization block
-                <Initializer> = Attribute definition
-                Initialization block
-            - Constructors (3):
-                ClassWithInitializers()
-                ClassWithInitializers(String)
-                ClassWithInitializers(Boolean)
-            - Methods (7):
-                initializeFromStaticAttributeDefinition()
-                initializeFromStaticInitializationBlock()
-                initializeFromStaticInitializationBlock2()
-                initializeFromAttributeDefinition()
-                initializeFromInstantiationBlock()
-                initializeFromSecondInstantiationBlock()
-                initializeFromConstructor()
-
-        In ClassWithInnerClass: 1
-            <Initializer>
-
-        In class _Anonymous(InnerClass) (in ClassWithInnerClass): 2
-            <Initializer>
-            ClassWithInnerClass(), the implicit constructor
-
-         */
-        for (Class c : entitiesOfType(Class.class)) {
-            if(!c.getIsStub()) {
-                System.out.println(c.getName());
-                for (TMethod m : c.getMethods()) {
-                    System.out.print("    " + m.getName() + " isStatic:" + ((Method) m).getIsClassSide());
-                    if (((Method) m).getIsInitializer()) {
-                        System.out.println(" isInitializationBlock: " + ((Initializer) m).getIsInitializationBlock());
-                    } else {
-                        System.out.println(" ");
-                    }
-                }
-            }
-        };
-        assertEquals(21,methods.size());
+        assertEquals(25,methods.size());
     }
 
     @Test
     public void testNumberOfInitializers() {
+    	parse("src/test/resources/initializers");
+    	
         Collection<Initializer> initializers = entitiesOfType(Initializer.class);
         assertEquals(13, initializers.size());
     }
 
     @Test
     public void testConstructors() {
+    	parse("src/test/resources/initializers");
+    	
         Collection<Initializer> constructors = entitiesOfType(Initializer.class).stream().filter(Initializer::getIsConstructor).toList();
 
          /*
@@ -109,6 +71,7 @@ public class VerveineJTest_Initializers extends VerveineJTest_Basic {
 
     @Test
     public void testInstanceInitializationBlocks() {
+    	parse("src/test/resources/initializers");
 
         Collection<Initializer> initializers = entitiesOfType(Initializer.class);
         Predicate<Initializer> isInstanceInitializationBlock = initializer -> initializer.getIsInitializationBlock() && !initializer.getIsClassSide();
@@ -125,6 +88,7 @@ public class VerveineJTest_Initializers extends VerveineJTest_Basic {
 
     @Test
     public void testStaticInitializationBlock() {
+    	parse("src/test/resources/initializers");
 
         Collection<Initializer> initializers = entitiesOfType(Initializer.class);
 
@@ -141,6 +105,8 @@ public class VerveineJTest_Initializers extends VerveineJTest_Basic {
 
     @Test
     public void testClassWithInnerClass() {
+    	parse("src/test/resources/initializers");
+    	
         Class classWithInnerClass = detectFamixElement(Class.class, "ClassWithInnerClass");
         assertNotNull(classWithInnerClass);
 
@@ -159,6 +125,8 @@ public class VerveineJTest_Initializers extends VerveineJTest_Basic {
 
     @Test
     public void testInnerClass() {
+    	parse("src/test/resources/initializers");
+    	
         Class innerClass = detectFamixElement(Class.class, "_Anonymous(InnerClass)");
         assertNotNull(innerClass);
 
@@ -175,5 +143,50 @@ public class VerveineJTest_Initializers extends VerveineJTest_Basic {
         var foundAttribute = firstElt(firstElt(initializer.getAccesses()).getCandidates());
         assertEquals(firstElt(innerClass.getAttributes()), foundAttribute);
     }
+    
+    @Test
+    public void testInitializerOfClassUsedInStaticInitializer() {
+    	parse(new String[] {
+        		"src/test/resources/initializers/MyClassUserInInitializer.java",
+        		"src/test/resources/initializers/MyClass.java"
+        		});
+        
+        PrimitiveType voidType = detectFamixElement(PrimitiveType.class, "void");
+        Initializer initializer = (Initializer)detectFamixElement(Class.class, "MyClass").getMethods().iterator().next();
+        assertEquals(voidType, initializer.getTyping().getDeclaredType());
+    }
+    
+    @Test
+    public void testNotConfusingConstructorsWhenParsingInitializerFirst() {
+    	parse(new String[] {
+        		"src/test/resources/initializers/MyClassUserInInitializer.java",
+        		"src/test/resources/initializers/MyClassUser.java",
+        		"src/test/resources/initializers/MyClass.java"
+        		});
+        
+        Collection<TMethod> methods = detectFamixElement(Class.class, "MyClass").getMethods();
+        
+        Initializer firstConstructor = (Initializer) methods.stream().filter(m -> m.getNumberOfParameters().equals(0)).findFirst().get();
+        Initializer secondConstructor = (Initializer) methods.stream().filter(m -> m.getNumberOfParameters().equals(1)).findFirst().get();
+        
+        assertEquals(1, firstConstructor.getIncomingInvocations().size());
+        assertEquals(1, secondConstructor.getIncomingInvocations().size());
+    }
+    
+    @Test
+    public void testNotConfusingConstructorsWhenParsingInitializerSecond() {
+    	parse(new String[] {
+        		"src/test/resources/initializers/MyClassUser.java",
+        		"src/test/resources/initializers/MyClassUserInInitializer.java",
+        		"src/test/resources/initializers/MyClass.java"
+        		});
 
+        Collection<TMethod> methods = detectFamixElement(Class.class, "MyClass").getMethods();
+
+        Initializer firstConstructor = (Initializer) methods.stream().filter(m -> m.getNumberOfParameters().equals(0)).findFirst().get();
+        Initializer secondConstructor = (Initializer) methods.stream().filter(m -> m.getNumberOfParameters().equals(1)).findFirst().get();
+        
+        assertEquals(1, firstConstructor.getIncomingInvocations().size());
+        assertEquals(1, secondConstructor.getIncomingInvocations().size());
+    }
 }

--- a/app/src/test/resources/initializers/MyClass.java
+++ b/app/src/test/resources/initializers/MyClass.java
@@ -1,0 +1,9 @@
+package initializers;
+
+public class MyClass {
+    
+	public MyClass() { }
+    
+    //A second constructor, to check that VVJ does not get confused
+    public MyClass(int x) { }
+}

--- a/app/src/test/resources/initializers/MyClassUser.java
+++ b/app/src/test/resources/initializers/MyClassUser.java
@@ -1,0 +1,7 @@
+package initializers;
+
+public class MyClassUser {
+	public void aMethod() {
+        new MyClass();
+    }
+}

--- a/app/src/test/resources/initializers/MyClassUserInInitializer.java
+++ b/app/src/test/resources/initializers/MyClassUserInInitializer.java
@@ -1,0 +1,7 @@
+package initializers;
+
+public class MyClassUserInInitializer {
+
+    public static final MyClass X = new MyClass(1);
+    
+}


### PR DESCRIPTION
There is code that looks up constructors by name in a class.
This creates lots of problems, because we can have many constructors with != number of arguments, but they generally have the same name :').

The binding is always there except for border cases where: the code is not there AND the dependency does not have the compiled version either!

Otherwise, looking them up by ID/type binding is enough

Probably we should add a test for the border case above also