### PR TITLE
Anonymous EnumValues evolution

### DIFF
--- a/app/src/main/java/fr/inria/verveine/extractor/java/utils/Util.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/utils/Util.java
@@ -27,6 +27,14 @@ public class Util {
 		return EntityDictionary.ANONYMOUS_NAME_PREFIX + "(" +anonSuperTypeName+")";
 	}
 
+
+	/**
+	 * helper to "normalize" an "anonymous" Enum name
+	 */
+	public static String stringForAnonymousEnum(String enumValueName, String superEnumName) {
+		return enumValueName + "(" + superEnumName + ")";
+	}
+
 	/**
 	 * Helper to compute the name of a JDT Type
 	 */

--- a/app/src/main/java/fr/inria/verveine/extractor/java/visitors/GetVisitedEntityAbstractVisitor.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/visitors/GetVisitedEntityAbstractVisitor.java
@@ -159,7 +159,7 @@ public abstract class GetVisitedEntityAbstractVisitor extends ASTVisitor {
 	}
 
 	protected void endVisitAnonymousClassDeclaration(AnonymousClassDeclaration node) {
-		if (context.top() instanceof org.moosetechnology.model.famix.famixjavaentities.Class) {
+		if (context.top() instanceof org.moosetechnology.model.famix.famixjavaentities.Type) {
 			context.pop();
 		}
 		if (!anonymousSuperTypeName.empty()) {

--- a/app/src/main/java/fr/inria/verveine/extractor/java/visitors/GetVisitedEntityAbstractVisitor.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/visitors/GetVisitedEntityAbstractVisitor.java
@@ -148,7 +148,7 @@ public abstract class GetVisitedEntityAbstractVisitor extends ASTVisitor {
 
 		ITypeBinding bnd = (ITypeBinding) StubBinding.getDeclarationBinding(node);
 		if(bnd.isEnum()){
-			fmx = this.dico.getFamixEnum(bnd, Util.stringForAnonymousName(getAnonymousSuperTypeName(), context), /*owner*/(ContainerEntity) context.top());
+			fmx = this.dico.getFamixEnum(bnd, Util.stringForAnonymousEnum(bnd.getDeclaringMember().getName(),context.top().getName()), /*owner*/(ContainerEntity) context.top());
 		} else{
 			fmx = this.dico.getFamixClass(bnd, Util.stringForAnonymousName(getAnonymousSuperTypeName(), context), /*owner*/(ContainerEntity) context.top());
 		}

--- a/app/src/main/java/fr/inria/verveine/extractor/java/visitors/GetVisitedEntityAbstractVisitor.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/visitors/GetVisitedEntityAbstractVisitor.java
@@ -143,12 +143,15 @@ public abstract class GetVisitedEntityAbstractVisitor extends ASTVisitor {
 	 * The body of an anonymous class declaration appears within a ClassInstanceCreation<br>
 	 * See also field {@link GetVisitedEntityAbstractVisitor#anonymousSuperTypeName}
 	 */
-	protected org.moosetechnology.model.famix.famixjavaentities.Class visitAnonymousClassDeclaration(AnonymousClassDeclaration node) {
-		org.moosetechnology.model.famix.famixjavaentities.Class fmx;
+	protected org.moosetechnology.model.famix.famixjavaentities.Type visitAnonymousClassDeclaration(AnonymousClassDeclaration node) {
+		org.moosetechnology.model.famix.famixjavaentities.Type fmx;
 
 		ITypeBinding bnd = (ITypeBinding) StubBinding.getDeclarationBinding(node);
-
-		fmx = this.dico.getFamixClass(bnd, Util.stringForAnonymousName(getAnonymousSuperTypeName(), context), /*owner*/(ContainerEntity) context.top());
+		if(bnd.isEnum()){
+			fmx = this.dico.getFamixEnum(bnd, Util.stringForAnonymousName(getAnonymousSuperTypeName(), context), /*owner*/(ContainerEntity) context.top());
+		} else{
+			fmx = this.dico.getFamixClass(bnd, Util.stringForAnonymousName(getAnonymousSuperTypeName(), context), /*owner*/(ContainerEntity) context.top());
+		}
 		if (fmx != null) {
 			this.context.pushType(fmx);
 		}

--- a/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorClassMethodDef.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorClassMethodDef.java
@@ -138,6 +138,7 @@ public class VisitorClassMethodDef extends GetVisitedEntityAbstractVisitor {
             Enum famixEnum = (Enum) context.topType();
             fmx = this.dico.ensureFamixEnum(bnd, Util.stringForAnonymousName(getAnonymousSuperTypeName(), context),/*owner*/famixEnum);
             EnumValue enumValue = this.dico.ensureFamixEnumValue((IVariableBinding) bnd.getDeclaringMember(), bnd.getDeclaringMember().getName(), famixEnum);
+            this.dico.ensureFamixEntityTyping(bnd,enumValue,fmx);
         } else {
             fmx = this.dico.ensureFamixClass(bnd, Util.stringForAnonymousName(getAnonymousSuperTypeName(), context), (ContainerEntity) /*owner*/context.top(),
                     /*isGeneric*/false, modifiers);

--- a/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorClassMethodDef.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorClassMethodDef.java
@@ -8,12 +8,12 @@ import java.util.List;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.eclipse.jdt.core.dom.*;
-import org.moosetechnology.model.famix.famixjavaentities.AnnotationType;
-import org.moosetechnology.model.famix.famixjavaentities.AnnotationTypeAttribute;
-import org.moosetechnology.model.famix.famixjavaentities.ContainerEntity;
-import org.moosetechnology.model.famix.famixjavaentities.Method;
-import org.moosetechnology.model.famix.famixjavaentities.ParametricClass;
+import org.eclipse.jdt.core.dom.Initializer;
+import org.eclipse.jdt.core.dom.TypeParameter;
+import org.moosetechnology.model.famix.famixjavaentities.*;
+import org.moosetechnology.model.famix.famixjavaentities.Enum;
 import org.moosetechnology.model.famix.famixtraits.TMethod;
+import org.moosetechnology.model.famix.famixtraits.TNamedEntity;
 import org.moosetechnology.model.famix.famixtraits.TWithMethods;
 import org.moosetechnology.model.famix.famixtraits.TWithTypes;
 
@@ -32,7 +32,7 @@ public class VisitorClassMethodDef extends GetVisitedEntityAbstractVisitor {
     protected MessageDigest md5;
 
     public VisitorClassMethodDef(EntityDictionary dico, VerveineJOptions options) {
-		super( dico, options);
+        super(dico, options);
         try {
             md5 = MessageDigest.getInstance("MD5");
         } catch (NoSuchAlgorithmException e) {
@@ -41,571 +41,547 @@ public class VisitorClassMethodDef extends GetVisitedEntityAbstractVisitor {
         }
     }
 
-	// VISITOR METHODS
+    // VISITOR METHODS
 
-	@Override
-	public boolean visit(CompilationUnit node) {
-		visitCompilationUnit(node);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(CompilationUnit node) {
+        visitCompilationUnit(node);
+        return super.visit(node);
+    }
 
-	@Override
-	public void endVisit(CompilationUnit node) {
-		endVisitCompilationUnit(node);
-	}
+    @Override
+    public void endVisit(CompilationUnit node) {
+        endVisitCompilationUnit(node);
+    }
 
-	/*
-	 * Can only be a class or interface declaration
-	 * Local type: see comment of visit(ClassInstanceCreation node)
-	 */
-	@Override
-	public boolean visit(TypeDeclaration node) {
-		//		System.err.println("TRACE, Visiting TypeDeclaration: "+node.getName().getIdentifier());
-		ITypeBinding bnd = (ITypeBinding) StubBinding.getDeclarationBinding(node);
+    /*
+     * Can only be a class or interface declaration
+     * Local type: see comment of visit(ClassInstanceCreation node)
+     */
+    @Override
+    public boolean visit(TypeDeclaration node) {
+        //		System.err.println("TRACE, Visiting TypeDeclaration: "+node.getName().getIdentifier());
+        ITypeBinding bnd = (ITypeBinding) StubBinding.getDeclarationBinding(node);
 
-		@SuppressWarnings("unchecked")
-		List<TypeParameter> typeParameters = (List<TypeParameter>) node.typeParameters();
+        @SuppressWarnings("unchecked") List<TypeParameter> typeParameters = (List<TypeParameter>) node.typeParameters();
 
-		// may be could use this.referredType instead of dico.ensureFamixClass ?
-		org.moosetechnology.model.famix.famixtraits.TType fmx;
-		if (bnd.isInterface()) {
-			fmx = dico.ensureFamixInterface(
-				bnd, 
-				/*name*/node.getName().getIdentifier(), 
-				(TWithTypes) 
-				/*owner*/context.top(), 
-				/*isGeneric*/typeParameters.size()>0,
-				node.getModifiers());
-		} else if (dico.isThrowable(bnd)) {
-			fmx = dico.ensureFamixException(
-				bnd, 
-				/*name*/node.getName().getIdentifier(), 
-				(TWithTypes) 
-				/*owner*/context.top(), 
-				/*isGeneric*/typeParameters.size()>0,
-				node.getModifiers());
-		} else {
-			fmx = dico.ensureFamixClass(
-					bnd, 
-					/*name*/node.getName().getIdentifier(), 
-					/*owner*/context.top(), 
-					/*isGeneric*/typeParameters.size()>0,
-					node.getModifiers());
-		}
-		if (fmx != null) {
-			Util.recursivelySetIsStub(fmx, false);
+        // may be could use this.referredType instead of dico.ensureFamixClass ?
+        org.moosetechnology.model.famix.famixtraits.TType fmx;
+        if (bnd.isInterface()) {
+            fmx = dico.ensureFamixInterface(bnd,
+                    /*name*/node.getName().getIdentifier(), (TWithTypes)
+                            /*owner*/context.top(),
+                    /*isGeneric*/typeParameters.size() > 0, node.getModifiers());
+        } else if (dico.isThrowable(bnd)) {
+            fmx = dico.ensureFamixException(bnd,
+                    /*name*/node.getName().getIdentifier(), (TWithTypes)
+                            /*owner*/context.top(),
+                    /*isGeneric*/typeParameters.size() > 0, node.getModifiers());
+        } else {
+            fmx = dico.ensureFamixClass(bnd,
+                    /*name*/node.getName().getIdentifier(),
+                    /*owner*/context.top(),
+                    /*isGeneric*/typeParameters.size() > 0, node.getModifiers());
+        }
+        if (fmx != null) {
+            Util.recursivelySetIsStub(fmx, false);
 
-			// if it is a generic and some parameterizedTypes were created for it,
-			// they are marked as stub which is not right
-			if (typeParameters.size() > 0) {
-				for (ParametricClass candidate : dico.getEntityByName(ParametricClass.class,
-						node.getName().getIdentifier())) {
-					candidate.setIsStub(false);
-				}
-			}
+            // if it is a generic and some parameterizedTypes were created for it,
+            // they are marked as stub which is not right
+            if (typeParameters.size() > 0) {
+                for (ParametricClass candidate : dico.getEntityByName(ParametricClass.class, node.getName().getIdentifier())) {
+                    candidate.setIsStub(false);
+                }
+            }
 
-			this.context.pushType(fmx);
+            this.context.pushType(fmx);
 
-			if (options.withAnchors()) {
-				dico.addSourceAnchor(fmx, node);
-			}
+            if (options.withAnchors()) {
+                dico.addSourceAnchor(fmx, node);
+            }
 
 
-			return super.visit(node);
-		} else {
-			return false;
-		}
-	}
+            return super.visit(node);
+        } else {
+            return false;
+        }
+    }
 
-	@Override
-	public void endVisit(TypeDeclaration node) {
-		this.context.popType();
-		super.endVisit(node);
-	}
+    @Override
+    public void endVisit(TypeDeclaration node) {
+        this.context.popType();
+        super.endVisit(node);
+    }
 
-	/**
-	 * See field {@link VisitorClassMethodDef#anonymousSuperTypeName}<br>
-	 * We could test if it is a local type (inner/anonymous) and not define it in case it does not make any reference
-	 * to anything outside its owner class. But it would be a lot of work for probably little gain.
-	 */
-	@Override
-	public boolean visit(ClassInstanceCreation node) {
-		//		System.err.println("TRACE, Visiting ClassInstanceCreation: " + node);
-		possiblyAnonymousClassDeclaration(node);
-		return super.visit(node);
-	}
+    /**
+     * See field {@link VisitorClassMethodDef#anonymousSuperTypeName}<br>
+     * We could test if it is a local type (inner/anonymous) and not define it in case it does not make any reference
+     * to anything outside its owner class. But it would be a lot of work for probably little gain.
+     */
+    @Override
+    public boolean visit(ClassInstanceCreation node) {
+        //		System.err.println("TRACE, Visiting ClassInstanceCreation: " + node);
+        possiblyAnonymousClassDeclaration(node);
+        return super.visit(node);
+    }
 
-	/**
-	 * See field {@link VisitorClassMethodDef#anonymousSuperTypeName}
-	 */
-	@Override
-	public boolean visit(AnonymousClassDeclaration node) {
-		//		System.err.println("TRACE, Visiting AnonymousClassDeclaration");
-		org.moosetechnology.model.famix.famixjavaentities.Type fmx;
-		ITypeBinding bnd = (ITypeBinding) StubBinding.getDeclarationBinding(node);
+    /**
+     * See field {@link VisitorClassMethodDef#anonymousSuperTypeName}
+     */
+    @Override
+    public boolean visit(AnonymousClassDeclaration node) {
+        org.moosetechnology.model.famix.famixjavaentities.Type fmx;
+        ITypeBinding bnd = (ITypeBinding) StubBinding.getDeclarationBinding(node);
 
-		int modifiers = (bnd != null) ? bnd.getModifiers() : EntityDictionary.UNKNOWN_MODIFIERS;
-		if (bnd.isInterface()) {
-			fmx = this.dico.ensureFamixInterface(
-					bnd, Util.stringForAnonymousName(getAnonymousSuperTypeName(), context), 
-					(ContainerEntity) 
-					/*owner*/context.top(), 
-					/*isGeneric*/false, 
-					modifiers);
-		} else {
-			fmx = this.dico.ensureFamixClass(
-					bnd, Util.stringForAnonymousName(getAnonymousSuperTypeName(), context), 
-					(ContainerEntity) 
-					/*owner*/context.top(), 
-					/*isGeneric*/false, 
-					modifiers);
-		}
-
-		if (fmx != null) {
-			Util.recursivelySetIsStub(fmx, false);
-
-			if (options.withAnchors()) {
-				dico.addSourceAnchor(fmx, node);
-			}
-			this.context.pushType(fmx);
-			return super.visit(node);
-		} else {
-			return false;
-		}
-	}
-
-	@Override
-	public void endVisit(AnonymousClassDeclaration node) {
-		if (!anonymousSuperTypeName.empty()) {
-			anonymousSuperTypeName.pop();
-		}
-		this.context.popType();
-		super.endVisit(node);
-	}
-
-	@Override
-	public boolean visit(EnumDeclaration node) {
-//		System.err.println("TRACE, Visiting EnumDeclaration: "+node.getName().getIdentifier());
-		ITypeBinding bnd = (ITypeBinding) StubBinding.getDeclarationBinding(node);
-
-		org.moosetechnology.model.famix.famixjavaentities.Enum fmx = dico.ensureFamixEnum(bnd, node.getName().getIdentifier(), (TWithTypes) context.top());
-		if (fmx != null) {
-			Util.recursivelySetIsStub(fmx, false);
-
-			this.context.pushType(fmx);
-			if (options.withAnchors()) {
-				dico.addSourceAnchor(fmx, node);
-			}
-			return super.visit(node);
-		} else {
-			return false;
-		}
-	}
-
-	@Override
-	public void endVisit(EnumDeclaration node) {
-		this.context.popType();
-		super.endVisit(node);
-	}
-
-	@Override
-	public boolean visit(AnnotationTypeDeclaration node) {
-		ITypeBinding bnd = node.resolveBinding();
-		AnnotationType fmx = dico.ensureFamixAnnotationType(bnd, node.getName().getIdentifier(), (ContainerEntity) context.top());
-		if (fmx != null) {
-			Util.recursivelySetIsStub(fmx, false);
-			if (options.withAnchors()) {
-				dico.addSourceAnchor(fmx, node);
-			}
-
-			context.pushType(fmx);
-			return super.visit(node);
-		}
-		else {
-			context.pushType(null);
-			return false;
-		}
-	}
-
-	@Override
-	public void endVisit(AnnotationTypeDeclaration node) {
-		this.context.popType();
-		super.endVisit(node);
-	}
-
-	/**
-     * MethodDeclaration ::=
-     *     [ Javadoc ] { ExtendedModifier } [ &lt; TypeParameter { , TypeParameter } &gt; ] ( Type | void )
-     *         Identifier (
-     *             [ ReceiverParameter , ] [ FormalParameter { , FormalParameter } ]
-     *         ) { Dimension }
-     *         [ throws Type { , Type } ]
-     *         ( Block | ; )
-     *  Also includes ConstructorDeclaration (same thing without return type)
-     *
-	 * Local type: same as {@link VisitorClassMethodDef#visit(ClassInstanceCreation)}, 
-	 * we create it even if it is a local method because there are too many ways it can access external things
-	 */
-	@SuppressWarnings("unchecked")
-	@Override
-	public boolean visit(MethodDeclaration node) {
-		IMethodBinding bnd = (IMethodBinding) StubBinding.getDeclarationBinding(node);
-        Collection<String> paramTypes = new ArrayList<>();
-        for (SingleVariableDeclaration param : (List<SingleVariableDeclaration>) node.parameters()) {
-            paramTypes.add( Util.jdtTypeName(param.getType()));
+        int modifiers = (bnd != null) ? bnd.getModifiers() : EntityDictionary.UNKNOWN_MODIFIERS;
+        if (bnd.isEnum()) {
+            Enum famixEnum = (Enum) context.topType();
+            fmx = this.dico.ensureFamixEnum(bnd, Util.stringForAnonymousName(getAnonymousSuperTypeName(), context),/*owner*/famixEnum);
+            EnumValue enumValue = this.dico.ensureFamixEnumValue((IVariableBinding) bnd.getDeclaringMember(), bnd.getDeclaringMember().getName(), famixEnum);
+        } else {
+            fmx = this.dico.ensureFamixClass(bnd, Util.stringForAnonymousName(getAnonymousSuperTypeName(), context), (ContainerEntity) /*owner*/context.top(),
+                    /*isGeneric*/false, modifiers);
         }
 
-		Method fmx = dico.ensureFamixMethod(
-				bnd, 
-				node.getName().getIdentifier(), 
-				paramTypes, 
-				/*returnType*/null, 
-				(TWithMethods) /*owner*/context.topType(), 
-				node.getModifiers());
+        if (fmx != null) {
+            Util.recursivelySetIsStub(fmx, false);
 
-		if (fmx != null) {
-			fmx.setIsStub(false);
-			// fmx.setBodyHash(this.computeHashForMethodBody(node));
+            if (options.withAnchors()) {
+                dico.addSourceAnchor(fmx, node);
+            }
+            this.context.pushType(fmx);
+            return super.visit(node);
+        } else {
+            return false;
+        }
+    }
 
-			this.context.pushMethod(fmx);
+    @Override
+    public void endVisit(AnonymousClassDeclaration node) {
+        if (!anonymousSuperTypeName.empty()) {
+            anonymousSuperTypeName.pop();
+        }
+        this.context.popType();
+        super.endVisit(node);
+    }
 
-			if (options.withAnchors()) {
-				dico.addSourceAnchor(fmx, node);
-			}
+    @Override
+    public boolean visit(EnumDeclaration node) {
+//		System.err.println("TRACE, Visiting EnumDeclaration: "+node.getName().getIdentifier());
+        ITypeBinding bnd = (ITypeBinding) StubBinding.getDeclarationBinding(node);
 
-			if (node.getBody() != null) {
-				context.setTopMethodCyclo(1);
-			} else {
-				// In interfaces you don't need to explicitly define the method as abstract
-				// However, if they don't have a body, they are!
-				fmx.setIsAbstract(true);
-			}
-			return super.visit(node);
-		} else {
-			this.context.pushMethod(null);
-			return false;
-		}
-	}
+        org.moosetechnology.model.famix.famixjavaentities.Enum fmx = dico.ensureFamixEnum(bnd, node.getName().getIdentifier(), (TWithTypes) context.top());
+        if (fmx != null) {
+            Util.recursivelySetIsStub(fmx, false);
 
-	private String computeHashForMethodBody(MethodDeclaration node) {
-		Block body = node.getBody();
-		if ( (body == null) || (md5 == null) ) {
+            this.context.pushType(fmx);
+            if (options.withAnchors()) {
+                dico.addSourceAnchor(fmx, node);
+            }
+            return super.visit(node);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public void endVisit(EnumDeclaration node) {
+        this.context.popType();
+        super.endVisit(node);
+    }
+
+    @Override
+    public boolean visit(AnnotationTypeDeclaration node) {
+        ITypeBinding bnd = node.resolveBinding();
+        AnnotationType fmx = dico.ensureFamixAnnotationType(bnd, node.getName().getIdentifier(), (ContainerEntity) context.top());
+        if (fmx != null) {
+            Util.recursivelySetIsStub(fmx, false);
+            if (options.withAnchors()) {
+                dico.addSourceAnchor(fmx, node);
+            }
+
+            context.pushType(fmx);
+            return super.visit(node);
+        } else {
+            context.pushType(null);
+            return false;
+        }
+    }
+
+    @Override
+    public void endVisit(AnnotationTypeDeclaration node) {
+        this.context.popType();
+        super.endVisit(node);
+    }
+
+    /**
+     * MethodDeclaration ::=
+     * [ Javadoc ] { ExtendedModifier } [ &lt; TypeParameter { , TypeParameter } &gt; ] ( Type | void )
+     * Identifier (
+     * [ ReceiverParameter , ] [ FormalParameter { , FormalParameter } ]
+     * ) { Dimension }
+     * [ throws Type { , Type } ]
+     * ( Block | ; )
+     * Also includes ConstructorDeclaration (same thing without return type)
+     * <p>
+     * Local type: same as {@link VisitorClassMethodDef#visit(ClassInstanceCreation)},
+     * we create it even if it is a local method because there are too many ways it can access external things
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean visit(MethodDeclaration node) {
+        IMethodBinding bnd = (IMethodBinding) StubBinding.getDeclarationBinding(node);
+        Collection<String> paramTypes = new ArrayList<>();
+        for (SingleVariableDeclaration param : (List<SingleVariableDeclaration>) node.parameters()) {
+            paramTypes.add(Util.jdtTypeName(param.getType()));
+        }
+
+        Method fmx = dico.ensureFamixMethod(bnd, node.getName().getIdentifier(), paramTypes,
+                /*returnType*/null, (TWithMethods) /*owner*/context.topType(), node.getModifiers());
+
+        if (fmx != null) {
+            fmx.setIsStub(false);
+            // fmx.setBodyHash(this.computeHashForMethodBody(node));
+
+            this.context.pushMethod(fmx);
+
+            if (options.withAnchors()) {
+                dico.addSourceAnchor(fmx, node);
+            }
+
+            if (node.getBody() != null) {
+                context.setTopMethodCyclo(1);
+            } else {
+                // In interfaces you don't need to explicitly define the method as abstract
+                // However, if they don't have a body, they are!
+                fmx.setIsAbstract(true);
+            }
+            return super.visit(node);
+        } else {
+            this.context.pushMethod(null);
+            return false;
+        }
+    }
+
+    private String computeHashForMethodBody(MethodDeclaration node) {
+        Block body = node.getBody();
+        if ((body == null) || (md5 == null)) {
             return "0";
         }
         byte[] bytes = node.getBody().toString().replaceAll("\\r|\\n|\\t", "").getBytes();
 
-       return DigestUtils.md5Hex(bytes).toUpperCase();
-	}
+        return DigestUtils.md5Hex(bytes).toUpperCase();
+    }
 
-	@Override
-	public void endVisit(MethodDeclaration node) {
-		closeMethodDeclaration();
-		super.endVisit(node);
-	}
+    @Override
+    public void endVisit(MethodDeclaration node) {
+        closeMethodDeclaration();
+        super.endVisit(node);
+    }
 
-	/**
+    /**
      * BodyDeclaration ::=
-     *                [ ... ]
-     *                 FieldDeclaration
-     *                 Initializer
-     *                 MethodDeclaration (for methods and constructors)
+     * [ ... ]
+     * FieldDeclaration
+     * Initializer
+     * MethodDeclaration (for methods and constructors)
      * Initializer ::=
-     *      [ static ] Block
+     * [ static ] Block
      */
     @Override
-	public boolean visit(Initializer node) {
-		Method fmx = (Method) createInitBlock(Modifier.isStatic(node.getModifiers()), true);
-		// init-block don't have return type so no need to create a reference from this class to the "declared return type" class when classSummary is TRUE
-		// also no parameters specified here, so no references to create either
+    public boolean visit(Initializer node) {
+        Method fmx = (Method) createInitBlock(Modifier.isStatic(node.getModifiers()), true);
+        // init-block don't have return type so no need to create a reference from this class to the "declared return type" class when classSummary is TRUE
+        // also no parameters specified here, so no references to create either
 
-		if (fmx != null) {
+        if (fmx != null) {
             dico.setMethodModifiers(fmx, node.getModifiers());
             if (options.withAnchors()) {
-            	dico.addSourceAnchor(fmx, node);
-			}
+                dico.addSourceAnchor(fmx, node);
+            }
 
-			if (node.getBody() != null) {
-				context.setTopMethodCyclo(1);
-			}
+            if (node.getBody() != null) {
+                context.setTopMethodCyclo(1);
+            }
 
-			return super.visit(node);
-		} else {
-			this.context.pushMethod(null);   // because endVisit(Initializer) will pop it out
-			return false;
-		}
-	}
+            return super.visit(node);
+        } else {
+            this.context.pushMethod(null);   // because endVisit(Initializer) will pop it out
+            return false;
+        }
+    }
 
-	@Override
-	public void endVisit(Initializer node) {
-		closeMethodDeclaration();
-		super.endVisit(node);
-	}
+    @Override
+    public void endVisit(Initializer node) {
+        closeMethodDeclaration();
+        super.endVisit(node);
+    }
 
-	@SuppressWarnings("unchecked")
-	@Override
-	public boolean visit(EnumConstantDeclaration node) {
-		for (Expression expr : (List<Expression>)node.arguments()) {
-			if (expr != null) {
-				createInitBlock(true , false); // Enum Constants are static
-				break;  // we created the INIT_BLOCK, no need to look for other declaration that would only ensure the same creation
-			}
-		}
-		return super.visit(node);
-	
-	}
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean visit(EnumConstantDeclaration node) {
+        for (Expression expr : (List<Expression>) node.arguments()) {
+            if (expr != null) {
+                createInitBlock(true, false); // Enum Constants are static
+                break;  // we created the INIT_BLOCK, no need to look for other declaration that would only ensure the same creation
+            }
+        }
+        return super.visit(node);
+
+    }
 
     public void endVisit(EnumConstantDeclaration node) {
         closeOptionalInitBlock();
     }
 
-	@SuppressWarnings("unchecked")
-	@Override
-	public boolean visit(FieldDeclaration node) {
-		boolean hasInitBlock = false;
-		for (VariableDeclaration varDecl : (List<VariableDeclaration>)node.fragments() ) {
-			if (varDecl.getInitializer() != null) {
-				createInitBlock(Modifier.isStatic(node.getModifiers()), false);
-				hasInitBlock = true;
-				break;  // we created the INIT_BLOCK, no need to look for other declaration that would only ensure the same creation
-			}
-		}
-		return hasInitBlock;
-	}
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean visit(FieldDeclaration node) {
+        boolean hasInitBlock = false;
+        for (VariableDeclaration varDecl : (List<VariableDeclaration>) node.fragments()) {
+            if (varDecl.getInitializer() != null) {
+                createInitBlock(Modifier.isStatic(node.getModifiers()), false);
+                hasInitBlock = true;
+                break;  // we created the INIT_BLOCK, no need to look for other declaration that would only ensure the same creation
+            }
+        }
+        return hasInitBlock;
+    }
 
     public void endVisit(FieldDeclaration node) {
         closeOptionalInitBlock();
     }
 
-	@Override
-	public boolean visit(AnnotationTypeMemberDeclaration node) {
+    @Override
+    public boolean visit(AnnotationTypeMemberDeclaration node) {
 //		System.err.println("TRACE, Visiting AnnotationTypeMemberDeclaration: "+node.getName().getIdentifier());
-		IMethodBinding bnd = node.resolveBinding();
+        IMethodBinding bnd = node.resolveBinding();
 
-		// note"Annotation members looks like methods, but they are closer to attributes
-		AnnotationTypeAttribute fmx = dico.ensureFamixAnnotationTypeAttribute(bnd, node.getName().getIdentifier(), (AnnotationType) context.topType());
-		if (fmx != null) {
-			fmx.setIsStub(false);
-			if (options.withAnchors()) {
-				dico.addSourceAnchor(fmx, node);
-			}
+        // note"Annotation members looks like methods, but they are closer to attributes
+        AnnotationTypeAttribute fmx = dico.ensureFamixAnnotationTypeAttribute(bnd, node.getName().getIdentifier(), (AnnotationType) context.topType());
+        if (fmx != null) {
+            fmx.setIsStub(false);
+            if (options.withAnchors()) {
+                dico.addSourceAnchor(fmx, node);
+            }
 
-			context.pushAnnotationMember(fmx);
-			return super.visit(node);
-		} else {
-			context.pushAnnotationMember(null);
-			return false;
-		}
-	}
+            context.pushAnnotationMember(fmx);
+            return super.visit(node);
+        } else {
+            context.pushAnnotationMember(null);
+            return false;
+        }
+    }
 
-	@Override
-	public void endVisit(AnnotationTypeMemberDeclaration node) {
-		this.context.popAnnotationMember();
-		super.endVisit(node);
-	}
+    @Override
+    public void endVisit(AnnotationTypeMemberDeclaration node) {
+        this.context.popAnnotationMember();
+        super.endVisit(node);
+    }
 
-	@Override
-	public boolean visit(ConstructorInvocation node) {
-		//		System.err.println("TRACE, Visiting ConstructorInvocation: ");
-		this.context.addTopMethodNOS(1);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(ConstructorInvocation node) {
+        //		System.err.println("TRACE, Visiting ConstructorInvocation: ");
+        this.context.addTopMethodNOS(1);
+        return super.visit(node);
+    }
 
-	@Override
-	public boolean visit(SuperConstructorInvocation node) {
-		this.context.addTopMethodNOS(1);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(SuperConstructorInvocation node) {
+        this.context.addTopMethodNOS(1);
+        return super.visit(node);
+    }
 
-	// "SomeClass.class"
-	public boolean visit(TypeLiteral node) {
-		dico.ensureFamixMetaClass(null);
-		return false;
-	}
+    // "SomeClass.class"
+    public boolean visit(TypeLiteral node) {
+        dico.ensureFamixMetaClass(null);
+        return false;
+    }
 
-	@Override
-	public boolean visit(ThrowStatement node) {
-		this.context.addTopMethodNOS(1);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(ThrowStatement node) {
+        this.context.addTopMethodNOS(1);
+        return super.visit(node);
+    }
 
-	@Override
-	public boolean visit(CatchClause node) {
-		this.context.addTopMethodCyclo(1);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(CatchClause node) {
+        this.context.addTopMethodCyclo(1);
+        return super.visit(node);
+    }
 
-	@Override
-	public boolean visit(AssertStatement node) {
-		this.context.addTopMethodNOS(1);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(AssertStatement node) {
+        this.context.addTopMethodNOS(1);
+        return super.visit(node);
+    }
 
-	@Override
-	public boolean visit(Assignment node) {
-		this.context.addTopMethodNOS(1);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(Assignment node) {
+        this.context.addTopMethodNOS(1);
+        return super.visit(node);
+    }
 
-	@Override
-	public boolean visit(ContinueStatement node) {
-		this.context.addTopMethodNOS(1);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(ContinueStatement node) {
+        this.context.addTopMethodNOS(1);
+        return super.visit(node);
+    }
 
-	@Override
-	public boolean visit(DoStatement node) {
-		this.context.addTopMethodCyclo(1);
-		this.context.addTopMethodNOS(1);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(DoStatement node) {
+        this.context.addTopMethodCyclo(1);
+        this.context.addTopMethodNOS(1);
+        return super.visit(node);
+    }
 
-	@Override
-	public boolean visit(ExpressionStatement node) {
-		this.context.addTopMethodNOS(1);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(ExpressionStatement node) {
+        this.context.addTopMethodNOS(1);
+        return super.visit(node);
+    }
 
-	@Override
-	public boolean visit(EnhancedForStatement node) {
-		this.context.addTopMethodCyclo(1);
-		this.context.addTopMethodNOS(1);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(EnhancedForStatement node) {
+        this.context.addTopMethodCyclo(1);
+        this.context.addTopMethodNOS(1);
+        return super.visit(node);
+    }
 
-	@Override
-	public boolean visit(ForStatement node) {
-		this.context.addTopMethodCyclo(1);
-		this.context.addTopMethodNOS(1);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(ForStatement node) {
+        this.context.addTopMethodCyclo(1);
+        this.context.addTopMethodNOS(1);
+        return super.visit(node);
+    }
 
-	@Override
-	public boolean visit(IfStatement node) {
-		this.context.addTopMethodCyclo(1);
-		this.context.addTopMethodNOS(1);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(IfStatement node) {
+        this.context.addTopMethodCyclo(1);
+        this.context.addTopMethodNOS(1);
+        return super.visit(node);
+    }
 
-	@Override
-	public boolean visit(ReturnStatement node) {
-		this.context.addTopMethodNOS(1);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(ReturnStatement node) {
+        this.context.addTopMethodNOS(1);
+        return super.visit(node);
+    }
 
-	@Override
-	public boolean visit(SwitchCase node) {
-		this.context.addTopMethodCyclo(1);
-		this.context.addTopMethodNOS(1);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(SwitchCase node) {
+        this.context.addTopMethodCyclo(1);
+        this.context.addTopMethodNOS(1);
+        return super.visit(node);
+    }
 
-	@Override
-	public boolean visit(SwitchStatement node) {
-		this.context.addTopMethodNOS(1);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(SwitchStatement node) {
+        this.context.addTopMethodNOS(1);
+        return super.visit(node);
+    }
 
-	@Override
-	public boolean visit(SynchronizedStatement node) {
-		this.context.addTopMethodNOS(1);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(SynchronizedStatement node) {
+        this.context.addTopMethodNOS(1);
+        return super.visit(node);
+    }
 
-	@Override
-	public boolean visit(TryStatement node) {
-		this.context.addTopMethodCyclo(1);
-		this.context.addTopMethodNOS(1);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(TryStatement node) {
+        this.context.addTopMethodCyclo(1);
+        this.context.addTopMethodNOS(1);
+        return super.visit(node);
+    }
 
-	@Override
-	public boolean visit(VariableDeclarationStatement node) {
-		this.context.addTopMethodNOS(1);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(VariableDeclarationStatement node) {
+        this.context.addTopMethodNOS(1);
+        return super.visit(node);
+    }
 
-	@Override
-	public boolean visit(WhileStatement node) {
-		this.context.addTopMethodCyclo(1);
-		this.context.addTopMethodNOS(1);
-		return super.visit(node);
-	}
+    @Override
+    public boolean visit(WhileStatement node) {
+        this.context.addTopMethodCyclo(1);
+        this.context.addTopMethodNOS(1);
+        return super.visit(node);
+    }
 
-	// UTILITY METHODS
+    // UTILITY METHODS
 
     /**
      * REnsures the creation of the fake method: {@link EntityDictionary#INIT_BLOCK_NAME}
-     *
+     * <p>
      * Used in the case of instance/class initializer and initializing expressions of FieldDeclarations and EnumConstantDeclarations
-	 */
-	protected TMethod createInitBlock(Boolean isStatic, Boolean isInitializationBlock) {
-		// putting field's initialization code in an INIT_BLOCK_NAME method
-		Method ctxtMeth = (Method) this.context.topMethod();
-		if (ctxtMeth != null && !ctxtMeth.getIsInitializer() && ctxtMeth.getIsClassSide() != isStatic) {
-			ctxtMeth = null;
-		} else {
-			if (ctxtMeth != null && ctxtMeth.getParentType() != context.topType()) {
-				/* We are in a field initialization in an anonymous class created in another field initialization.
-				 * In this example, we are in the declaration of aField2:
-				 * class Class1 {
-				 * 	class Class2 {}
-				 *  Class2 aField1 = new Class2() {
-				 * 		Class3 aField2 = xyz;
-				 *   }
-				 * }
-				 *
-				 * This means we have to create the Initializer of the inner class (in the example above, Class2::<Initializer>).
-				 */
-				ctxtMeth = null;
-			}
-		}
-		if (ctxtMeth == null) {
-			ctxtMeth = dico.ensureFamixInitializer(
-					(TWithMethods) context.topType(), isStatic, isInitializationBlock);
-			ctxtMeth.setIsStub(false);
-			ctxtMeth.setIsDead(false);
-			// initialization block doesn't have return type so no need to create a reference from its class to the "declared return type" class when classSummary is TRUE
-			pushInitBlockMethod(ctxtMeth);
-		}
-		return ctxtMeth;
-	}
+     */
+    protected TMethod createInitBlock(Boolean isStatic, Boolean isInitializationBlock) {
+        // putting field's initialization code in an INIT_BLOCK_NAME method
+        Method ctxtMeth = (Method) this.context.topMethod();
+        if (ctxtMeth != null && !ctxtMeth.getIsInitializer() && ctxtMeth.getIsClassSide() != isStatic) {
+            ctxtMeth = null;
+        } else {
+            if (ctxtMeth != null && ctxtMeth.getParentType() != context.topType()) {
+                /* We are in a field initialization in an anonymous class created in another field initialization.
+                 * In this example, we are in the declaration of aField2:
+                 * class Class1 {
+                 * 	class Class2 {}
+                 *  Class2 aField1 = new Class2() {
+                 * 		Class3 aField2 = xyz;
+                 *   }
+                 * }
+                 *
+                 * This means we have to create the Initializer of the inner class (in the example above, Class2::<Initializer>).
+                 */
+                ctxtMeth = null;
+            }
+        }
+        if (ctxtMeth == null) {
+            ctxtMeth = dico.ensureFamixInitializer((TWithMethods) context.topType(), isStatic, isInitializationBlock);
+            ctxtMeth.setIsStub(false);
+            ctxtMeth.setIsDead(false);
+            // initialization block doesn't have return type so no need to create a reference from its class to the "declared return type" class when classSummary is TRUE
+            pushInitBlockMethod(ctxtMeth);
+        }
+        return ctxtMeth;
+    }
 
-	/**
-	 * Special method InitBlock may be "created" in various steps,
-	 * mainly when attributes are declared+initialized with the result of a method call.<br>
-	 * In such a case, we need to recover the previous metric values to add to them
-	 * @param ctxtMeth -- the InitBlock FamixMethod
-	 */
-	protected void pushInitBlockMethod(TMethod ctxtMeth) {
-		int nos = (ctxtMeth.getNumberOfStatements() == null) ? 0 : ctxtMeth.getNumberOfStatements().intValue();
-		int cyclo = (ctxtMeth.getCyclomaticComplexity() == null) ? 0 : ctxtMeth.getCyclomaticComplexity().intValue();
-		this.context.pushMethod(ctxtMeth);
-		if ((nos != 0) || (cyclo != 0)) {
-			context.setTopMethodNOS(nos);
-			context.setTopMethodCyclo(cyclo);
-		}
-	}
+    /**
+     * Special method InitBlock may be "created" in various steps,
+     * mainly when attributes are declared+initialized with the result of a method call.<br>
+     * In such a case, we need to recover the previous metric values to add to them
+     *
+     * @param ctxtMeth -- the InitBlock FamixMethod
+     */
+    protected void pushInitBlockMethod(TMethod ctxtMeth) {
+        int nos = (ctxtMeth.getNumberOfStatements() == null) ? 0 : ctxtMeth.getNumberOfStatements().intValue();
+        int cyclo = (ctxtMeth.getCyclomaticComplexity() == null) ? 0 : ctxtMeth.getCyclomaticComplexity().intValue();
+        this.context.pushMethod(ctxtMeth);
+        if ((nos != 0) || (cyclo != 0)) {
+            context.setTopMethodNOS(nos);
+            context.setTopMethodCyclo(cyclo);
+        }
+    }
 
-	protected void closeOptionalInitBlock() {
-		Method ctxtMeth = (Method)this.context.topMethod();
-		if ((ctxtMeth != null) && ctxtMeth.getIsInitializer() && !ctxtMeth.getIsConstructor()) {
-			closeMethodDeclaration();
-		}
-	}
+    protected void closeOptionalInitBlock() {
+        Method ctxtMeth = (Method) this.context.topMethod();
+        if ((ctxtMeth != null) && ctxtMeth.getIsInitializer() && !ctxtMeth.getIsConstructor()) {
+            closeMethodDeclaration();
+        }
+    }
 
-	/**
-	 * When closing a method declaration, we need to take care of some metrics that are also collected
-	 */
-	protected void closeMethodDeclaration() {
-		if (context.topMethod() != null) {
-			int cyclo = context.getTopMethodCyclo();
-			int nos = context.getTopMethodNOS();
-			Method fmx = (Method) this.context.popMethod();
-			if (fmx != null) {
-				fmx.setNumberOfStatements(nos);
-				fmx.setCyclomaticComplexity(cyclo);
-			}
-		}
-	}
+    /**
+     * When closing a method declaration, we need to take care of some metrics that are also collected
+     */
+    protected void closeMethodDeclaration() {
+        if (context.topMethod() != null) {
+            int cyclo = context.getTopMethodCyclo();
+            int nos = context.getTopMethodNOS();
+            Method fmx = (Method) this.context.popMethod();
+            if (fmx != null) {
+                fmx.setNumberOfStatements(nos);
+                fmx.setCyclomaticComplexity(cyclo);
+            }
+        }
+    }
 
 }

--- a/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorClassMethodDef.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorClassMethodDef.java
@@ -320,23 +320,6 @@ public class VisitorClassMethodDef extends GetVisitedEntityAbstractVisitor {
 
     @SuppressWarnings("unchecked")
     @Override
-    public boolean visit(EnumConstantDeclaration node) {
-        for (Expression expr : (List<Expression>) node.arguments()) {
-            if (expr != null) {
-                createInitBlock(true, false); // Enum Constants are static
-                break;  // we created the INIT_BLOCK, no need to look for other declaration that would only ensure the same creation
-            }
-        }
-        return super.visit(node);
-
-    }
-
-    public void endVisit(EnumConstantDeclaration node) {
-        closeOptionalInitBlock();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
     public boolean visit(FieldDeclaration node) {
         boolean hasInitBlock = false;
         for (VariableDeclaration varDecl : (List<VariableDeclaration>) node.fragments()) {

--- a/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorClassMethodDef.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorClassMethodDef.java
@@ -136,7 +136,7 @@ public class VisitorClassMethodDef extends GetVisitedEntityAbstractVisitor {
         int modifiers = (bnd != null) ? bnd.getModifiers() : EntityDictionary.UNKNOWN_MODIFIERS;
         if (bnd.isEnum()) {
             Enum famixEnum = (Enum) context.topType();
-            fmx = this.dico.ensureFamixEnum(bnd, Util.stringForAnonymousName(getAnonymousSuperTypeName(), context),/*owner*/famixEnum);
+            fmx = this.dico.ensureFamixEnum(bnd, Util.stringForAnonymousEnum(bnd.getDeclaringMember().getName(),famixEnum.getName()),/*owner*/famixEnum);
             EnumValue enumValue = this.dico.ensureFamixEnumValue((IVariableBinding) bnd.getDeclaringMember(), bnd.getDeclaringMember().getName(), famixEnum);
             this.dico.ensureFamixEntityTyping(bnd,enumValue,fmx);
         } else {

--- a/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorVarsDef.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorVarsDef.java
@@ -195,11 +195,6 @@ public class VisitorVarsDef extends GetVisitedEntityAbstractVisitor {
 		return super.visit(node);
 	}
 
-	@Override
-	public void endVisit(EnumConstantDeclaration node) {
-		context.popType();
-	}
-
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean visit(FieldDeclaration node) {

--- a/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorVarsDef.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorVarsDef.java
@@ -8,9 +8,7 @@ import org.eclipse.jdt.core.dom.*;
 import org.eclipse.jdt.core.dom.Initializer;
 import org.moosetechnology.model.famix.famixjavaentities.*;
 import org.moosetechnology.model.famix.famixjavaentities.Enum;
-import org.moosetechnology.model.famix.famixtraits.TCanBeStub;
 import org.moosetechnology.model.famix.famixtraits.TNamedEntity;
-import org.moosetechnology.model.famix.famixtraits.TSourceEntity;
 import org.moosetechnology.model.famix.famixtraits.TStructuralEntity;
 import org.moosetechnology.model.famix.famixtraits.TWithAttributes;
 
@@ -78,6 +76,7 @@ public class VisitorVarsDef extends GetVisitedEntityAbstractVisitor {
 	public void endVisit(AnonymousClassDeclaration node) {
 		endVisitAnonymousClassDeclaration( node);
 	}
+
 
 	@Override
 	public boolean visit(EnumDeclaration node) {
@@ -191,9 +190,14 @@ public class VisitorVarsDef extends GetVisitedEntityAbstractVisitor {
 
 	@Override
 	public boolean visit(EnumConstantDeclaration node) {
-		EnumValue ev = dico.ensureFamixEnumValue(node.resolveVariable(), node.getName().getIdentifier(), /*owner*/(Enum)context.topType());
+		EnumValue ev = dico.ensureFamixEnumValue(node.resolveVariable(), node.getName().getIdentifier(), /*owner*/(Enum) context.topType());
 		ev.setIsStub(false);
 		return super.visit(node);
+	}
+
+	@Override
+	public void endVisit(EnumConstantDeclaration node) {
+		context.popType();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/app/src/main/java/fr/inria/verveine/extractor/java/visitors/refvisitors/VisitorAccessRef.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/visitors/refvisitors/VisitorAccessRef.java
@@ -150,8 +150,15 @@ public class VisitorAccessRef extends AbstractRefVisitor {
 	@Override
 	public boolean visit(EnumDeclaration node) {
 		if (visitEnumDeclaration( node) != null) {
-            // no need to visit node.enumConstants() in this visitor
-            visitNodeList(node.bodyDeclarations());
+			// Bypasses standard enumConstants traversal to prevent accessor generation on the constants themselves.
+			// Explicitly delegates to anonymous class declarations (if any) to capture accesses inside the anonymous class.
+			for (EnumConstantDeclaration enumCons : (List<EnumConstantDeclaration>) node.enumConstants()) {
+				AnonymousClassDeclaration anonymousClassDeclaration = enumCons.getAnonymousClassDeclaration();
+				if (anonymousClassDeclaration != null) {
+					anonymousClassDeclaration.accept(this);
+				}
+			}
+			visitNodeList(node.bodyDeclarations());
         }
 		return false;
 	}
@@ -485,7 +492,6 @@ public class VisitorAccessRef extends AbstractRefVisitor {
 
 	@Override
 	public boolean visit(SimpleName node) {
-        //System.err.println("visit(SimpleName)");
         IBinding bnd = node.resolveBinding();
         if ( (bnd != null) && (bnd.getKind() == IBinding.VARIABLE) && (context.topMethod() != null) ) {
             // could be a variable, a field, an enumValue, ...

--- a/app/src/main/java/fr/inria/verveine/extractor/java/visitors/refvisitors/VisitorInheritanceRef.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/visitors/refvisitors/VisitorInheritanceRef.java
@@ -51,10 +51,21 @@ public class VisitorInheritanceRef extends GetVisitedEntityAbstractVisitor {
 
 		// ITypeBinding bnd = node.resolveBinding();
 		ITypeBinding bnd = (ITypeBinding) StubBinding.getDeclarationBinding(node);
-		org.moosetechnology.model.famix.famixjavaentities.Class fmx = this.dico.getFamixClass(bnd, Util.stringForAnonymousName(getAnonymousSuperTypeName(), context), /*owner*/(ContainerEntity) context.top());
+
+		Type fmx;
+		TWithInheritances fmxIn;
+		if(bnd.isEnum()){
+			org.moosetechnology.model.famix.famixjavaentities.Enum famixEnum = this.dico.getFamixEnum(bnd, Util.stringForAnonymousName(getAnonymousSuperTypeName(), context), /*owner*/(ContainerEntity) context.top());
+			fmx = famixEnum;
+			fmxIn = famixEnum;
+		} else{
+			org.moosetechnology.model.famix.famixjavaentities.Class famixClass = this.dico.getFamixClass(bnd, Util.stringForAnonymousName(getAnonymousSuperTypeName(), context), /*owner*/(ContainerEntity) context.top());
+			fmx = famixClass;
+			fmxIn = famixClass;
+		}
 
 		if ((fmx != null) && (bnd != null)) {
-			ensureInheritances(bnd, fmx);
+			ensureInheritances(bnd, fmxIn);
 
 			this.context.pushType(fmx);
 			return super.visit(node);

--- a/app/src/main/java/fr/inria/verveine/extractor/java/visitors/refvisitors/VisitorInheritanceRef.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/visitors/refvisitors/VisitorInheritanceRef.java
@@ -55,7 +55,7 @@ public class VisitorInheritanceRef extends GetVisitedEntityAbstractVisitor {
 		Type fmx;
 		TWithInheritances fmxIn;
 		if(bnd.isEnum()){
-			org.moosetechnology.model.famix.famixjavaentities.Enum famixEnum = this.dico.getFamixEnum(bnd, Util.stringForAnonymousName(getAnonymousSuperTypeName(), context), /*owner*/(ContainerEntity) context.top());
+			org.moosetechnology.model.famix.famixjavaentities.Enum famixEnum = this.dico.getFamixEnum(bnd, Util.stringForAnonymousEnum(bnd.getDeclaringMember().getName(),context.top().getName()), /*owner*/(ContainerEntity) context.top());
 			fmx = famixEnum;
 			fmxIn = famixEnum;
 		} else{

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_AdHoc.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_AdHoc.java
@@ -1007,6 +1007,15 @@ public class VerveineJTest_AdHoc extends VerveineJTest_Basic {
         }
     }
 
+	@Test
+	public void testAnonymousInterface() {
+		//Check that anonymous entities created from interfaces are Anonymous classes
+		parse(new String[]{"src/test/resources/ad_hoc/InterfaceWithAnonymous.java"});
+
+		Class clazz = detectFamixElement(Class.class, "_Anonymous(InterfaceWithAnonymous)");
+		assertNotNull(clazz);
+	}
+
     @Test
     public void testEnumValueParentEnum() {
 		parse(new String[]{"src/test/resources/ad_hoc/Number.java"});
@@ -1031,16 +1040,28 @@ public class VerveineJTest_AdHoc extends VerveineJTest_Basic {
 
 		EnumValue zero = detectFamixElement(EnumValue.class,"ZERO");
 		assertNotNull(zero.getDeclaredType());
+
+		Enum zeroClass = detectFamixElement(Enum.class,"ZERO(Number)");
+		assertNotNull(zeroClass);
+
+		assertSame(zeroClass,zero.getDeclaredType());
 	}
 
 	@Test
-	public void testAnonymousInterface(){
-		//Check that anonymous entities created from interfaces are Anonymous classes
-		parse(new String[]{"src/test/resources/ad_hoc/InterfaceWithAnonymous.java"});
+	public void testEnumMethodDeclaredInAnonymousEnumHasCorrectParentType(){
+		parse(new String[]{"src/test/resources/ad_hoc/Number.java"});
 
-		Class clazz = detectFamixElement(Class.class,"_Anonymous(InterfaceWithAnonymous)");
-		assertNotNull(clazz);
+		Enum zeroClass = detectFamixElement(Enum.class,"ZERO(Number)");
+		assertNotNull(zeroClass);
+
+		Method addMethod = (Method) firstElt(zeroClass.getMethods());
+		assertNotNull(addMethod);
+
+		assertEquals("add", addMethod.getName());
+		assertSame(zeroClass,addMethod.getParentType());
+		assertEquals("Override", ((AnnotationType) firstElt(addMethod.getAnnotationInstances()).getAnnotationType()).getName());
 	}
+
 
 
 }

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_AdHoc.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_AdHoc.java
@@ -1032,6 +1032,10 @@ public class VerveineJTest_AdHoc extends VerveineJTest_Basic {
 		EnumValue two = detectFamixElement(EnumValue.class,"TWO");
 		assertNotNull(two);
 		assertSame(numberEnum, two.getParentEnum());
+
+		EnumValue three = detectFamixElement(EnumValue.class,"THREE");
+		assertNotNull(three);
+		assertSame(numberEnum, three.getParentEnum());
     }
 
 	@Test
@@ -1062,7 +1066,21 @@ public class VerveineJTest_AdHoc extends VerveineJTest_Basic {
 		assertEquals("Override", ((AnnotationType) firstElt(addMethod.getAnnotationInstances()).getAnnotationType()).getName());
 	}
 
+	@Test
+	public void testEnumAttributeDeclaredInAnonymousEnumHasCorrectParentType(){
+		parse(new String[]{"src/test/resources/ad_hoc/Number.java"});
 
+		Enum oneClass = detectFamixElement(Enum.class,"ONE(Number)");
+		assertNotNull(oneClass);
+
+		Attribute value2 = (Attribute) firstElt(oneClass.getAttributes());
+		assertNotNull(value2);
+
+		assertEquals("value2", value2.getName());
+		assertSame(oneClass,value2.getParentType());
+
+		assertEquals(0, oneClass.getMethods().size()); // Doesn't have an initializer
+	}
 
 }
 

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_AdHoc.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_AdHoc.java
@@ -26,8 +26,6 @@ import org.moosetechnology.model.famix.famixtraits.*;
 
 import fr.inria.verveine.extractor.java.utils.Util;
 
-import javax.smartcardio.Card;
-
 /**
  * @author Nicolas Anquetil
  * @since November 25, 2010
@@ -1080,6 +1078,44 @@ public class VerveineJTest_AdHoc extends VerveineJTest_Basic {
 		assertSame(oneClass,value2.getParentType());
 
 		assertEquals(0, oneClass.getMethods().size()); // Doesn't have an initializer
+	}
+
+	@Test
+	public void testEnumAttributeDefinedInAnonymousEnumHasCorrectParentType(){
+		parse(new String[]{"src/test/resources/ad_hoc/Number.java"});
+
+		Enum twoEnum = detectFamixElement(Enum.class,"TWO(Number)");
+		assertNotNull(twoEnum);
+
+		Attribute value2 = (Attribute) firstElt(twoEnum.getAttributes());
+		assertNotNull(value2);
+
+		assertEquals("value2", value2.getName());
+		assertSame(twoEnum,value2.getParentType());
+
+		assertEquals(1, twoEnum.getMethods().size()); // Has an initializer
+		Initializer initializer = (Initializer) firstElt(twoEnum.getMethods());
+		assertEquals("<Initializer>", initializer.getName());
+		assertFalse(initializer.getIsClassSide());
+		assertEquals(1, initializer.numberOfAccesses());
+
+	}
+
+	@Test
+	public void testAnonymousClassWithAttributeDefinition(){
+		parse(new String[]{"src/test/resources/ad_hoc/AnonymousWithAccess.java"});
+
+		Class ownerClass = detectFamixElement(Class.class,"AnonymousWithAccess");
+		assertNotNull(ownerClass);
+
+		Method initializer = (Method) firstElt(ownerClass.getMethods());
+		assertNotNull(initializer);
+
+		Class anonymousClass = (Class) firstElt(initializer.getTypes());
+		assertNotNull(anonymousClass);
+
+		Method anonymousClassInitializer = (Method) anonymousClass.getMethods().stream().filter((m) -> ((Method) m).getName().equals("<Initializer>") ).findFirst().get();
+		assertEquals(1,anonymousClassInitializer.numberOfAccesses());
 	}
 
 }

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_AdHoc.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_AdHoc.java
@@ -527,7 +527,7 @@ public class VerveineJTest_AdHoc extends VerveineJTest_Basic {
 
 	@Test
 	public void testEnumAsVariableType() {
-		parse(new String[]{"src/test/resources/ad_hoc/Card.java", "src/test/resources/ad_hoc/Planet.java"});
+		parse(new String[]{"src/test/resources/ad_hoc/Card.java"});
 
 		org.moosetechnology.model.famix.famixjavaentities.Class card = detectFamixElement(org.moosetechnology.model.famix.famixjavaentities.Class.class, "Card");
 		assertNotNull(card);
@@ -990,7 +990,7 @@ public class VerveineJTest_AdHoc extends VerveineJTest_Basic {
     *    Issue: https://github.com/moosetechnology/VerveineJ/issues/184
     *    Regression test ensuring that Enum values defining methods have the typing information right for parameters.
      */
-    public void testEnumValuesHaveTheRightTypingOfMethodParamaters() {
+    public void testEnumValuesHaveTheRightTypingOfMethodParameters() {
         parse(new String[]{"src/test/resources/ad_hoc/Operation.java"});
 
         Collection<Method> methods = entitiesNamed(Method.class, "apply");
@@ -1006,6 +1006,43 @@ public class VerveineJTest_AdHoc extends VerveineJTest_Basic {
 
         }
     }
+
+    @Test
+    public void testEnumValueParentEnum() {
+		parse(new String[]{"src/test/resources/ad_hoc/Number.java"});
+
+		Enum numberEnum = detectFamixElement(Enum.class,"Number");
+		EnumValue zero = detectFamixElement(EnumValue.class,"ZERO");
+		assertNotNull(zero);
+		assertSame(numberEnum, zero.getParentEnum());
+
+		EnumValue one = detectFamixElement(EnumValue.class,"ONE");
+		assertNotNull(one);
+		assertSame(numberEnum, one.getParentEnum());
+
+		EnumValue two = detectFamixElement(EnumValue.class,"TWO");
+		assertNotNull(two);
+		assertSame(numberEnum, two.getParentEnum());
+    }
+
+	@Test
+	public void testEnumValueWithMethodsHasADeclaredType(){
+		parse(new String[]{"src/test/resources/ad_hoc/Number.java"});
+
+		EnumValue zero = detectFamixElement(EnumValue.class,"ZERO");
+		assertNotNull(zero.getDeclaredType());
+	}
+
+	@Test
+	public void testAnonymousInterface(){
+		//Check that anonymous entities created from interfaces are Anonymous classes
+		parse(new String[]{"src/test/resources/ad_hoc/InterfaceWithAnonymous.java"});
+
+		Class clazz = detectFamixElement(Class.class,"_Anonymous(InterfaceWithAnonymous)");
+		assertNotNull(clazz);
+	}
+
+
 }
 
 

--- a/app/src/test/resources/ad_hoc/AnonymousWithAccess.java
+++ b/app/src/test/resources/ad_hoc/AnonymousWithAccess.java
@@ -1,0 +1,5 @@
+package ad_hoc;
+
+public class AnonymousWithAccess {
+    private Object o = new Object() {private int i = 0;};
+}

--- a/app/src/test/resources/ad_hoc/InterfaceWithAnonymous.java
+++ b/app/src/test/resources/ad_hoc/InterfaceWithAnonymous.java
@@ -1,0 +1,9 @@
+public interface InterfaceWithAnonymous {
+
+InterfaceWithAnonymous i = new InterfaceWithAnonymous() {
+    public int toto() {
+        return 0;
+    }
+};
+
+}

--- a/app/src/test/resources/ad_hoc/Number.java
+++ b/app/src/test/resources/ad_hoc/Number.java
@@ -1,0 +1,23 @@
+public enum Number {
+    ZERO(0) {
+        @Override
+        public int add(int i) {
+            return i;
+        }
+    },
+    ONE(1) //{
+        //private int value2;
+    //}
+    ,
+    TWO(2);
+
+    private int value;
+
+    Number(int i) {
+        value = i;
+    }
+
+    public int add(int i) {
+        return i + value;
+    }
+}

--- a/app/src/test/resources/ad_hoc/Number.java
+++ b/app/src/test/resources/ad_hoc/Number.java
@@ -1,3 +1,5 @@
+package ad_hoc;
+
 public enum Number {
     ZERO(0) {
         @Override
@@ -5,11 +7,11 @@ public enum Number {
             return i;
         }
     },
-    ONE(1) //{
-        //private int value2;
-    //}
-    ,
-    TWO(2);
+    ONE(1) {
+        private int value2;
+    },
+    TWO(2){ private int value2 = 2;},
+    THREE(3);
 
     private int value;
 


### PR DESCRIPTION
Fix EnumValue "anonymous" classes representation.

- Link the EnumConstant and its anonymous class using the parentType relation.
- Rename the "anonymous" class using the EnumConstant name
- Fix accesses on variable inside anonymous enum classes