### PR TITLE
fix: method with the `native` modifier are no longer abstract

### DIFF
--- a/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorClassMethodDef.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorClassMethodDef.java
@@ -275,7 +275,9 @@ public class VisitorClassMethodDef extends GetVisitedEntityAbstractVisitor {
 
 			if (node.getBody() != null) {
 				context.setTopMethodCyclo(1);
-			} else {
+			} else if(!Modifier.isNative(node.getModifiers())) {
+				// If the method is native then it is not abstract, as it has a concrete implementation in C/C++
+
 				// In interfaces you don't need to explicitly define the method as abstract
 				// However, if they don't have a body, they are!
 				fmx.setIsAbstract(true);

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_AdHoc.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_AdHoc.java
@@ -1019,6 +1019,34 @@ public class VerveineJTest_AdHoc extends VerveineJTest_Basic {
 
         }
     }
+
+	@Test
+	public void testNativeMethodIsNotAbstract(){
+		parse(new String[]{"src/test/resources/ad_hoc/NativeExample.java"});
+
+		Class clazz = detectFamixElement(Class.class, "NativeExample");
+		assertNotNull(clazz);
+
+		Method nativeMethod = (Method) firstElt(clazz.getMethods());
+		assertNotNull(nativeMethod);
+
+		assertFalse(nativeMethod.getIsAbstract());
+	}
+
+	@Test
+	public void testNativeMethodOverride(){
+		parse(new String[]{"src/test/resources/ad_hoc/NativeExample.java"});
+
+		Class clazz = detectFamixElement(Class.class, "NotNativeExample");
+		assertNotNull(clazz);
+
+		Method notNativeMethod = (Method) firstElt(clazz.getMethods());
+		assertNotNull(notNativeMethod);
+
+		// Not abstract and is an override
+		assertFalse(notNativeMethod.getIsAbstract());
+		assertFalse(notNativeMethod.getAnnotationInstances().stream().anyMatch((annotation) -> annotation.toString().equals("Override")));
+	}
 }
 
 

--- a/app/src/test/resources/ad_hoc/NativeExample.java
+++ b/app/src/test/resources/ad_hoc/NativeExample.java
@@ -1,0 +1,12 @@
+package ad_hoc;
+
+public class NativeExample {
+	public native void foo();
+
+	public static class NotNativeExample extends NativeExample {
+
+		@Override
+		public void foo() {}
+	}
+}
+


### PR DESCRIPTION
Issue: #227
The proposal doesn't offer a complete solution for dealing with the 'native' modifier.

Here I only propose a modification to not handle the method with the `native` modifier as an abstract method.