### PR TITLE
Fix annotation member context in comment visitor

### DIFF
--- a/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorComments.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorComments.java
@@ -200,12 +200,19 @@ public class VisitorComments extends GetVisitedEntityAbstractVisitor {
 		endVisitMethodDeclaration(node);
 	}
 
+	@Override
 	public boolean visit(AnnotationTypeMemberDeclaration node) {
 		AnnotationTypeAttribute fmx = visitAnnotationTypeMemberDeclaration( node);
 
 		assignCommentsBefore(node, node.getJavadoc(), fmx);
 
 		return super.visit(node);
+	}
+
+	@Override
+	public void endVisit(AnnotationTypeMemberDeclaration node) {
+		this.context.popAnnotationMember();
+		super.endVisit(node);
 	}
 
 	@Override

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_CommentsMethod.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_CommentsMethod.java
@@ -248,4 +248,15 @@ public class VerveineJTest_CommentsMethod extends VerveineJTest_Basic {
         assertEquals(0, mth.getComments().size());
     }
 
+    @Test
+    public void testAnnotationMemberContextIsPoppedBeforeNestedEnum() {
+        parse(new String[] { "src/test/resources/comments/AnnotationWithNestedEnum.java" });
+
+        org.moosetechnology.model.famix.famixjavaentities.Enum nestedEnum =
+                detectFamixElement(org.moosetechnology.model.famix.famixjavaentities.Enum.class, "Feature");
+
+        assertNotNull("Nested enum should be modeled", nestedEnum);
+        assertEquals("Nested enum should receive its Javadoc comment", 1, nestedEnum.getComments().size());
+    }
+
 }

--- a/app/src/test/resources/comments/AnnotationWithNestedEnum.java
+++ b/app/src/test/resources/comments/AnnotationWithNestedEnum.java
@@ -1,0 +1,13 @@
+package comments;
+
+public @interface AnnotationWithNestedEnum {
+
+    boolean reflective() default false;
+
+    /**
+     * Nested declaration visited after the annotation member.
+     */
+    enum Feature {
+        ENABLED
+    }
+}


### PR DESCRIPTION
Fixes #248.

## Change
- Pop annotation member context in `VisitorComments` when leaving annotation type members.
- Add a focused comment fixture and test for an annotation member followed by a nested enum.