### PR TITLE
Fix comment visitor for lambda locals in field initializers

### DIFF
--- a/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorComments.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/visitors/defvisitors/VisitorComments.java
@@ -16,6 +16,7 @@ import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
 import org.eclipse.jdt.core.dom.Comment;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.EnumDeclaration;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
 import org.eclipse.jdt.core.dom.Initializer;
 import org.eclipse.jdt.core.dom.Javadoc;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
@@ -231,7 +232,7 @@ public class VisitorComments extends GetVisitedEntityAbstractVisitor {
 
 	@Override
 	public boolean visit(VariableDeclarationFragment node) {
-		if (classMemberDeclarations) {
+		if (classMemberDeclarations && node.getParent() instanceof FieldDeclaration) {
 			TWithComments fmx = dico.getFamixAttribute(node.resolveBinding(), node.getName().getIdentifier(), (TWithAttributes) context.topType());
 			if ( ! ((TCanBeStub) fmx).getIsStub() ) {
 				// if it is a stub, it might have been created by the getFamixAttribute just above

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_CommentsMethod.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_CommentsMethod.java
@@ -259,4 +259,15 @@ public class VerveineJTest_CommentsMethod extends VerveineJTest_Basic {
         assertEquals("Nested enum should receive its Javadoc comment", 1, nestedEnum.getComments().size());
     }
 
+    @Test
+    public void testFieldInitializerLambdaLocalCommentIsPreservedWithoutAttributeComment() {
+        parse(new String[] { "src/test/resources/comments/FieldInitializerLambdaLocal.java" });
+
+        Attribute task = detectFamixElement(Attribute.class, "task");
+
+        assertNotNull(task);
+        assertEquals(1, entitiesOfType(Comment.class).size());
+        assertEquals(0, task.getComments().size());
+    }
+
 }

--- a/app/src/test/resources/comments/FieldInitializerLambdaLocal.java
+++ b/app/src/test/resources/comments/FieldInitializerLambdaLocal.java
@@ -1,0 +1,9 @@
+package comments;
+
+public class FieldInitializerLambdaLocal {
+
+    private Runnable task = () -> {
+        // local value comment
+        String local = "value";
+    };
+}


### PR DESCRIPTION
Fixes #249.

## Change
- Restrict attribute comment assignment to variable fragments whose direct parent is a JDT `FieldDeclaration`.
- Add a focused field-initializer lambda fixture to cover a local declaration with a nearby comment.

## Notes
The lambda-local comment is still modeled by the existing containing-type comment assignment; it is no longer attached to the field attribute.