### PR TITLE
Fix incompatible FAMIX type recovery

### DIFF
--- a/app/src/main/java/fr/inria/verveine/extractor/java/EntityDictionary.java
+++ b/app/src/main/java/fr/inria/verveine/extractor/java/EntityDictionary.java
@@ -257,6 +257,21 @@ public class EntityDictionary {
 	}
 
 	/**
+	 * Returns the Famix Entity associated to the given key if it is an instance of the given Famix class.
+	 * This avoids recovering a binding as another kind of entity than the one requested.
+	 * @param key -- the key
+	 * @param fmxClass -- the expected Famix class
+	 * @return the Famix Entity associated to the binding or null if not found or not an instance of <b>fmxClass</b>
+	 */
+	protected <T extends TNamedEntity> T getEntityByKey(IBinding key, java.lang.Class<T> fmxClass) {
+		TNamedEntity fmx = getEntityByKey(key);
+		if (fmxClass.isInstance(fmx)) {
+			return fmxClass.cast(fmx);
+		}
+		return null;
+	}
+
+	/**
 	 * Returns the key associated to a Famix Entity.
 	 * @param e -- the Named entity
 	 * @return the key associated to this entity or null if none
@@ -320,7 +335,7 @@ public class EntityDictionary {
 		 */
 
 		if (bnd != null) {
-			fmx = (T) getEntityByKey(bnd);
+			fmx = getEntityByKey(bnd, fmxClass);
 			if (fmx != null) {
 				return fmx;
 			}
@@ -329,8 +344,7 @@ public class EntityDictionary {
 		// else
 		fmx = createFamixEntity(fmxClass, name);
 		if ( (bnd != null) && (fmx != null) ) {
-			keyToEntity.put(bnd, fmx);
-			entityToKey.put(fmx, bnd);
+			mapEntityToKey(bnd, fmx);
 		}
 		
 		return fmx;
@@ -1066,7 +1080,7 @@ public class EntityDictionary {
 		}
 
 		// ---------------- to avoid useless computations if we can
-		fmx = (Class) getEntityByKey(bnd);
+		fmx = getEntityByKey(bnd, Class.class);
 		if (fmx != null) {
 			return fmx;
 		}
@@ -1262,7 +1276,7 @@ public class EntityDictionary {
 		}
 
 		// ---------------- to avoid useless computations if we can
-		fmx = (Interface) getEntityByKey(bnd);
+		fmx = getEntityByKey(bnd, Interface.class);
 		if (fmx != null) {
 			return fmx;
 		}

--- a/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_TypeRecovery.java
+++ b/app/src/test/java/fr/inria/verveine/extractor/java/VerveineJTest_TypeRecovery.java
@@ -1,0 +1,45 @@
+package fr.inria.verveine.extractor.java;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Paths;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.moosetechnology.model.famix.famixjavaentities.Method;
+import org.moosetechnology.model.famix.famixjavaentities.ParametricInterface;
+import org.moosetechnology.model.famix.famixtraits.TNamedEntity;
+
+public class VerveineJTest_TypeRecovery extends VerveineJTest_Basic {
+
+    @Before
+    public void setUp() throws Exception {
+        parser = new VerveineJParser();
+        repo = parser.getFamixRepo();
+        parser.configure(new String[] {
+                "-jdkMode",
+                "-sysLibPath",
+                Paths.get(System.getProperty("java.home"), "lib", "jrt-fs.jar").toString(),
+                "-17",
+                "src/test/resources/type_recovery/java/util/RecoveredInterface.java",
+                "src/test/resources/type_recovery/java/util/stream/BindingRecoveryClient.java"
+        });
+        parser.parse();
+    }
+
+    /*
+     * JDT binding recovery can report the same binding key through incompatible
+     * class/interface paths. VerveineJ must check that a key mapping has the
+     * requested FAMIX kind before reusing it.
+     */
+    @Test
+    public void testRecoveredParameterizedInterfaceCanBeImplementedByLocalClass() {
+        assertNotNull(detectFamixElement(ParametricInterface.class, "RecoveredInterface"));
+
+        assertTrue("The local implementation method should be modeled",
+                entitiesNamed(Method.class, "next").stream()
+                .anyMatch(method -> method.getParentType() != null
+                        && ((TNamedEntity) method.getParentType()).getName().equals("LocalImplementation")));
+    }
+}

--- a/app/src/test/resources/type_recovery/java/util/RecoveredInterface.java
+++ b/app/src/test/resources/type_recovery/java/util/RecoveredInterface.java
@@ -1,0 +1,7 @@
+package java.util;
+
+public interface RecoveredInterface<T> {
+    int MARKER = 1;
+
+    RecoveredInterface<T> next();
+}

--- a/app/src/test/resources/type_recovery/java/util/stream/BindingRecoveryClient.java
+++ b/app/src/test/resources/type_recovery/java/util/stream/BindingRecoveryClient.java
@@ -1,0 +1,23 @@
+package java.util.stream;
+
+import java.util.RecoveredInterface;
+
+public class BindingRecoveryClient<E> {
+    /*
+     * Resolve RecoveredInterface once through a static member access before the
+     * local class asks for RecoveredInterface<E>. This reproduces the binding
+     * order where VerveineJ can see the same key through incompatible FAMIX
+     * class/interface lookup paths.
+     */
+    private static final int MARKER = RecoveredInterface.MARKER;
+
+    public void createRecoveredType() {
+        class LocalImplementation implements RecoveredInterface<E> {
+
+            @Override
+            public RecoveredInterface<E> next() {
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #247

## Change

- Reuse binding-key entries only when the stored FAMIX entity has the requested concrete kind.
- Add a small JDK-mode fixture for recovered parameterized interface bindings.

## Notes

The fixture keeps the java.util / java.util.stream package split because the failure depends on JDT recovery in JDK mode, but uses generic class names instead of JDK source copies.